### PR TITLE
Fix: correct setting of defaults in http_statuses, improve checking

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -116,9 +116,10 @@ end
 
 -- Some color for demo purposes
 local use_color = false
-local function green(str) return use_color and ("\027[32m" .. str .. "\027[0m") or str end
-local function red(str) return use_color and ("\027[31m" .. str .. "\027[0m") or str end
-local function worker_color(str) return use_color and ("\027["..tostring(31 + ngx.worker.pid() % 5).."m"..str.."\027[0m") or str end
+local id = function(x) return x end
+local green        = use_color and function(str) return ("\027[32m" .. str .. "\027[0m") end or id
+local red          = use_color and function(str) return ("\027[31m" .. str .. "\027[0m") end or id
+local worker_color = use_color and function(str) return ("\027["..tostring(31 + ngx.worker.pid() % 5).."m"..str.."\027[0m") end or id
 
 -- Debug function
 local function dump(...) print(require("pl.pretty").write({...})) end

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1040,9 +1040,13 @@ local function fill_in_settings(opts, defaults, ctx)
 
     if v then
       if type(v) == "table" then
-        ctx[#ctx + 1] = k
-        obj[k] = fill_in_settings(v, default, ctx)
-        ctx[#ctx + 1] = nil
+        if default[1] then -- do not recurse on arrays
+          obj[k] = v
+        else
+          ctx[#ctx + 1] = k
+          obj[k] = fill_in_settings(v, default, ctx)
+          ctx[#ctx + 1] = nil
+        end
       else
         if type(v) == "number" and (v < 0 or v > MAXNUM) then
           fail(ctx, k, "must be between 0 and " .. MAXNUM)

--- a/t/09-active_probes.t
+++ b/t/09-active_probes.t
@@ -126,3 +126,113 @@ healthy SUCCESS increment (2/3) for 127.0.0.1:2112
 healthy SUCCESS increment (3/3) for 127.0.0.1:2112
 event: target status '127.0.0.1:2112' from 'false' to 'true'
 checking unhealthy targets: nothing to do
+
+=== TEST 3: active probes, custom http status (regression test for pre-filled defaults)
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    server {
+        listen 2112;
+        location = /status {
+            return 500;
+        }
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+                type = "http",
+                checks = {
+                    active = {
+                        http_path = "/status",
+                        healthy  = {
+                            interval = 0.1,
+                            successes = 3,
+                        },
+                        unhealthy  = {
+                            interval = 0.1,
+                            http_failures = 3,
+                            http_statuses = { 429 },
+                        }
+                    },
+                }
+            })
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.sleep(0.5) -- wait for 5x the check interval
+            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+--- error_log
+checking unhealthy targets: nothing to do
+--- no_error_log
+checking healthy targets: nothing to do
+unhealthy HTTP increment (1/3) for 127.0.0.1:2112
+unhealthy HTTP increment (2/3) for 127.0.0.1:2112
+unhealthy HTTP increment (3/3) for 127.0.0.1:2112
+event: target status '127.0.0.1:2112' from 'true' to 'false'
+
+
+=== TEST 4: active probes, custom http status, node failing
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    server {
+        listen 2112;
+        location = /status {
+            return 401;
+        }
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+                type = "http",
+                checks = {
+                    active = {
+                        http_path = "/status",
+                        healthy  = {
+                            interval = 0.1,
+                            successes = 3,
+                        },
+                        unhealthy  = {
+                            interval = 0.1,
+                            http_failures = 3,
+                            http_statuses = { 401 },
+                        }
+                    },
+                }
+            })
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.sleep(0.5) -- wait for 5x the check interval
+            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+        }
+    }
+--- request
+GET /t
+--- response_body
+false
+--- error_log
+checking unhealthy targets: nothing to do
+unhealthy HTTP increment (1/3) for 127.0.0.1:2112
+unhealthy HTTP increment (2/3) for 127.0.0.1:2112
+unhealthy HTTP increment (3/3) for 127.0.0.1:2112
+event: target status '127.0.0.1:2112' from 'true' to 'false'
+checking healthy targets: nothing to do


### PR DESCRIPTION
### fix(settings) correct setting of defaults in http_statuses

Function `fill_in_settings` was recursing into the array and filling the numeric keys with defaults one by one. This meant that given a default of `{ 429, 500, 503 }`, if a user passed a value `{ 404 }`, the resulting config would be `{ 404, 500, 503 }`.

Includes a regression test to demonstrate the problem.

### feat(settings) add type and bounds checking to `checks` table

Does basic `type()`-checking on arguments, and a loose bounds checking to avoid the [problem](https://github.com/openresty/lua-nginx-module/issues/1278) with `ngx.timer.at`. I tested the library running on Kong, the added strictness does not affect it.
