### PR TITLE
add distinct ports for tests to avoid race conditions

### DIFF
--- a/t/03-get_target_status.t
+++ b/t/03-get_target_status.t
@@ -23,7 +23,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2115;
         location = /status {
             return 200;
         }
@@ -63,12 +63,12 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
-            checker:report_tcp_failure("127.0.0.1", 2112)
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
-            checker:report_success("127.0.0.1", 2112)
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            local ok, err = checker:add_target("127.0.0.1", 2115, nil, true)
+            ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- true
+            checker:report_tcp_failure("127.0.0.1", 2115)
+            ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- false
+            checker:report_success("127.0.0.1", 2115)
+            ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- true
         }
     }
 --- request

--- a/t/04-report_success.t
+++ b/t/04-report_success.t
@@ -25,7 +25,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2116;
         location = /status {
             return 200;
         }
@@ -66,16 +66,16 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, false)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, false)
-            checker:report_success("127.0.0.1", 2112, "active")
-            checker:report_success("127.0.0.1", 2113, "passive")
-            checker:report_success("127.0.0.1", 2112, "active")
-            checker:report_success("127.0.0.1", 2113, "passive")
-            checker:report_success("127.0.0.1", 2112, "active")
-            checker:report_success("127.0.0.1", 2113, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
-            ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- true
+            local ok, err = checker:add_target("127.0.0.1", 2116, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2118, nil, false)
+            checker:report_success("127.0.0.1", 2116, "active")
+            checker:report_success("127.0.0.1", 2118, "passive")
+            checker:report_success("127.0.0.1", 2116, "active")
+            checker:report_success("127.0.0.1", 2118, "passive")
+            checker:report_success("127.0.0.1", 2116, "active")
+            checker:report_success("127.0.0.1", 2118, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- true
         }
     }
 --- request
@@ -86,14 +86,14 @@ true
 --- error_log
 checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
-healthy SUCCESS increment (1/3) for 127.0.0.1:2112
-healthy SUCCESS increment (2/3) for 127.0.0.1:2112
-healthy SUCCESS increment (3/3) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'false' to 'true'
-healthy SUCCESS increment (1/3) for 127.0.0.1:2113
-healthy SUCCESS increment (2/3) for 127.0.0.1:2113
-healthy SUCCESS increment (3/3) for 127.0.0.1:2113
-event: target status '127.0.0.1:2113' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for 127.0.0.1:2116
+healthy SUCCESS increment (2/3) for 127.0.0.1:2116
+healthy SUCCESS increment (3/3) for 127.0.0.1:2116
+event: target status '127.0.0.1:2116' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for 127.0.0.1:2118
+healthy SUCCESS increment (2/3) for 127.0.0.1:2118
+healthy SUCCESS increment (3/3) for 127.0.0.1:2118
+event: target status '127.0.0.1:2118' from 'false' to 'true'
 
 
 === TEST 2: report_success() recovers TCP active = passive
@@ -102,7 +102,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2116;
         location = /status {
             return 200;
         }
@@ -143,16 +143,16 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, false)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, false)
-            checker:report_success("127.0.0.1", 2112, "active")
-            checker:report_success("127.0.0.1", 2113, "passive")
-            checker:report_success("127.0.0.1", 2112, "active")
-            checker:report_success("127.0.0.1", 2113, "passive")
-            checker:report_success("127.0.0.1", 2112, "active")
-            checker:report_success("127.0.0.1", 2113, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
-            ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- true
+            local ok, err = checker:add_target("127.0.0.1", 2116, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2118, nil, false)
+            checker:report_success("127.0.0.1", 2116, "active")
+            checker:report_success("127.0.0.1", 2118, "passive")
+            checker:report_success("127.0.0.1", 2116, "active")
+            checker:report_success("127.0.0.1", 2118, "passive")
+            checker:report_success("127.0.0.1", 2116, "active")
+            checker:report_success("127.0.0.1", 2118, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- true
         }
     }
 --- request
@@ -163,14 +163,14 @@ true
 --- error_log
 checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
-healthy SUCCESS increment (1/3) for 127.0.0.1:2112
-healthy SUCCESS increment (2/3) for 127.0.0.1:2112
-healthy SUCCESS increment (3/3) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'false' to 'true'
-healthy SUCCESS increment (1/3) for 127.0.0.1:2113
-healthy SUCCESS increment (2/3) for 127.0.0.1:2113
-healthy SUCCESS increment (3/3) for 127.0.0.1:2113
-event: target status '127.0.0.1:2113' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for 127.0.0.1:2116
+healthy SUCCESS increment (2/3) for 127.0.0.1:2116
+healthy SUCCESS increment (3/3) for 127.0.0.1:2116
+event: target status '127.0.0.1:2116' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for 127.0.0.1:2118
+healthy SUCCESS increment (2/3) for 127.0.0.1:2118
+healthy SUCCESS increment (3/3) for 127.0.0.1:2118
+event: target status '127.0.0.1:2118' from 'false' to 'true'
 
 === TEST 3: report_success() is a nop when active.healthy.sucesses == 0
 --- http_config eval
@@ -178,7 +178,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2116;
         location = /status {
             return 200;
         }
@@ -219,11 +219,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, false)
-            checker:report_success("127.0.0.1", 2112, "active")
-            checker:report_success("127.0.0.1", 2112, "active")
-            checker:report_success("127.0.0.1", 2112, "active")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            local ok, err = checker:add_target("127.0.0.1", 2116, nil, false)
+            checker:report_success("127.0.0.1", 2116, "active")
+            checker:report_success("127.0.0.1", 2116, "active")
+            checker:report_success("127.0.0.1", 2116, "active")
+            ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- false
         }
     }
 --- request
@@ -232,7 +232,7 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1:2112' from 'false' to 'true'
+event: target status '127.0.0.1:2116' from 'false' to 'true'
 
 
 
@@ -242,7 +242,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2113;
+        listen 2118;
         location = /status {
             return 200;
         }
@@ -283,11 +283,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, false)
-            checker:report_success("127.0.0.1", 2113, "passive")
-            checker:report_success("127.0.0.1", 2113, "passive")
-            checker:report_success("127.0.0.1", 2113, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
+            local ok, err = checker:add_target("127.0.0.1", 2118, nil, false)
+            checker:report_success("127.0.0.1", 2118, "passive")
+            checker:report_success("127.0.0.1", 2118, "passive")
+            checker:report_success("127.0.0.1", 2118, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- false
         }
     }
 --- request
@@ -296,4 +296,4 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1:2113' from 'false' to 'true'
+event: target status '127.0.0.1:2118' from 'false' to 'true'

--- a/t/05-report_failure.t
+++ b/t/05-report_failure.t
@@ -25,7 +25,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2117;
         location = /status {
             return 200;
         }
@@ -66,15 +66,15 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2117, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_failure("127.0.0.1", 2112, "active")
+            checker:report_failure("127.0.0.1", 2117, "active")
             checker:report_failure("127.0.0.1", 2113, "passive")
-            checker:report_failure("127.0.0.1", 2112, "active")
+            checker:report_failure("127.0.0.1", 2117, "active")
             checker:report_failure("127.0.0.1", 2113, "passive")
-            checker:report_failure("127.0.0.1", 2112, "active")
+            checker:report_failure("127.0.0.1", 2117, "active")
             checker:report_failure("127.0.0.1", 2113, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            ngx.say(checker:get_target_status("127.0.0.1", 2117))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
     }
@@ -86,10 +86,10 @@ false
 --- error_log
 checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
-unhealthy HTTP increment (1/3) for 127.0.0.1:2112
-unhealthy HTTP increment (2/3) for 127.0.0.1:2112
-unhealthy HTTP increment (3/3) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for 127.0.0.1:2117
+unhealthy HTTP increment (2/3) for 127.0.0.1:2117
+unhealthy HTTP increment (3/3) for 127.0.0.1:2117
+event: target status '127.0.0.1:2117' from 'true' to 'false'
 unhealthy HTTP increment (1/3) for 127.0.0.1:2113
 unhealthy HTTP increment (2/3) for 127.0.0.1:2113
 unhealthy HTTP increment (3/3) for 127.0.0.1:2113
@@ -102,7 +102,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2117;
         location = /status {
             return 200;
         }
@@ -143,15 +143,15 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2117, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_failure("127.0.0.1", 2112, "active")
+            checker:report_failure("127.0.0.1", 2117, "active")
             checker:report_failure("127.0.0.1", 2113, "passive")
-            checker:report_failure("127.0.0.1", 2112, "active")
+            checker:report_failure("127.0.0.1", 2117, "active")
             checker:report_failure("127.0.0.1", 2113, "passive")
-            checker:report_failure("127.0.0.1", 2112, "active")
+            checker:report_failure("127.0.0.1", 2117, "active")
             checker:report_failure("127.0.0.1", 2113, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            ngx.say(checker:get_target_status("127.0.0.1", 2117))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
     }
@@ -163,9 +163,9 @@ false
 --- error_log
 checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
-unhealthy TCP increment (1/2) for 127.0.0.1:2112
-unhealthy TCP increment (2/2) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+unhealthy TCP increment (1/2) for 127.0.0.1:2117
+unhealthy TCP increment (2/2) for 127.0.0.1:2117
+event: target status '127.0.0.1:2117' from 'true' to 'false'
 unhealthy TCP increment (1/2) for 127.0.0.1:2113
 unhealthy TCP increment (2/2) for 127.0.0.1:2113
 event: target status '127.0.0.1:2113' from 'true' to 'false'
@@ -177,7 +177,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2117;
         location = /status {
             return 200;
         }
@@ -218,15 +218,15 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2117, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_failure("127.0.0.1", 2112, "active")
+            checker:report_failure("127.0.0.1", 2117, "active")
             checker:report_failure("127.0.0.1", 2113, "passive")
-            checker:report_failure("127.0.0.1", 2112, "active")
+            checker:report_failure("127.0.0.1", 2117, "active")
             checker:report_failure("127.0.0.1", 2113, "passive")
-            checker:report_failure("127.0.0.1", 2112, "active")
+            checker:report_failure("127.0.0.1", 2117, "active")
             checker:report_failure("127.0.0.1", 2113, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2117))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- true
         }
     }
@@ -239,9 +239,9 @@ true
 checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
 --- no_error_log
-unhealthy TCP increment (1/2) for 127.0.0.1:2112
-unhealthy TCP increment (2/2) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+unhealthy TCP increment (1/2) for 127.0.0.1:2117
+unhealthy TCP increment (2/2) for 127.0.0.1:2117
+event: target status '127.0.0.1:2117' from 'true' to 'false'
 unhealthy TCP increment (1/2) for 127.0.0.1:2113
 unhealthy TCP increment (2/2) for 127.0.0.1:2113
 event: target status '127.0.0.1:2113' from 'true' to 'false'

--- a/t/06-report_http_status.t
+++ b/t/06-report_http_status.t
@@ -25,7 +25,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2119;
         location = /status {
             return 200;
         }
@@ -66,15 +66,15 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_http_status("127.0.0.1", 2112, 500, "active")
+            checker:report_http_status("127.0.0.1", 2119, 500, "active")
             checker:report_http_status("127.0.0.1", 2113, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 500, "active")
+            checker:report_http_status("127.0.0.1", 2119, 500, "active")
             checker:report_http_status("127.0.0.1", 2113, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 500, "active")
+            checker:report_http_status("127.0.0.1", 2119, 500, "active")
             checker:report_http_status("127.0.0.1", 2113, 500, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
     }
@@ -86,10 +86,10 @@ false
 --- error_log
 checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
-unhealthy HTTP increment (1/3) for 127.0.0.1:2112
-unhealthy HTTP increment (2/3) for 127.0.0.1:2112
-unhealthy HTTP increment (3/3) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for 127.0.0.1:2119
+unhealthy HTTP increment (2/3) for 127.0.0.1:2119
+unhealthy HTTP increment (3/3) for 127.0.0.1:2119
+event: target status '127.0.0.1:2119' from 'true' to 'false'
 unhealthy HTTP increment (1/3) for 127.0.0.1:2113
 unhealthy HTTP increment (2/3) for 127.0.0.1:2113
 unhealthy HTTP increment (3/3) for 127.0.0.1:2113
@@ -103,7 +103,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2119;
         location = /status {
             return 200;
         }
@@ -144,17 +144,17 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, false)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, false)
-            checker:report_http_status("127.0.0.1", 2112, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, 200, "active")
             checker:report_http_status("127.0.0.1", 2113, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, 200, "active")
             checker:report_http_status("127.0.0.1", 2113, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, 200, "active")
             checker:report_http_status("127.0.0.1", 2113, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, 200, "active")
             checker:report_http_status("127.0.0.1", 2113, 200, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- true
         }
     }
@@ -166,11 +166,11 @@ true
 --- error_log
 checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
-healthy SUCCESS increment (1/4) for 127.0.0.1:2112
-healthy SUCCESS increment (2/4) for 127.0.0.1:2112
-healthy SUCCESS increment (3/4) for 127.0.0.1:2112
-healthy SUCCESS increment (4/4) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'false' to 'true'
+healthy SUCCESS increment (1/4) for 127.0.0.1:2119
+healthy SUCCESS increment (2/4) for 127.0.0.1:2119
+healthy SUCCESS increment (3/4) for 127.0.0.1:2119
+healthy SUCCESS increment (4/4) for 127.0.0.1:2119
+event: target status '127.0.0.1:2119' from 'false' to 'true'
 healthy SUCCESS increment (1/4) for 127.0.0.1:2113
 healthy SUCCESS increment (2/4) for 127.0.0.1:2113
 healthy SUCCESS increment (3/4) for 127.0.0.1:2113
@@ -184,7 +184,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2119;
         location = /status {
             return 200;
         }
@@ -225,12 +225,12 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, false)
-            checker:report_http_status("127.0.0.1", 2112, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 200, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, false)
+            checker:report_http_status("127.0.0.1", 2119, 200, "passive")
+            checker:report_http_status("127.0.0.1", 2119, 200, "passive")
+            checker:report_http_status("127.0.0.1", 2119, 200, "passive")
+            checker:report_http_status("127.0.0.1", 2119, 200, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- false
         }
     }
 --- request
@@ -242,7 +242,7 @@ checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1:2112' from 'false' to 'true'
+event: target status '127.0.0.1:2119' from 'false' to 'true'
 
 
 === TEST 4: report_http_status() with success is a nop when active.healthy.successes == 0
@@ -251,7 +251,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2119;
         location = /status {
             return 200;
         }
@@ -292,12 +292,12 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, false)
-            checker:report_http_status("127.0.0.1", 2112, 200, "active")
-            checker:report_http_status("127.0.0.1", 2112, 200, "active")
-            checker:report_http_status("127.0.0.1", 2112, 200, "active")
-            checker:report_http_status("127.0.0.1", 2112, 200, "active")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, false)
+            checker:report_http_status("127.0.0.1", 2119, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, 200, "active")
+            ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- false
         }
     }
 --- request
@@ -309,7 +309,7 @@ checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1:2112' from 'false' to 'true'
+event: target status '127.0.0.1:2119' from 'false' to 'true'
 
 
 === TEST 5: report_http_status() with failure is a nop when passive.unhealthy.http_failures == 0
@@ -318,7 +318,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2119;
         location = /status {
             return 200;
         }
@@ -359,12 +359,12 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
-            checker:report_http_status("127.0.0.1", 2112, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2112, 500, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
+            checker:report_http_status("127.0.0.1", 2119, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, 500, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- true
         }
     }
 --- request
@@ -376,7 +376,7 @@ checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
 --- no_error_log
 unhealthy HTTP increment
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+event: target status '127.0.0.1:2119' from 'true' to 'false'
 
 
 === TEST 4: report_http_status() with success is a nop when active.unhealthy.http_failures == 0
@@ -385,7 +385,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2119;
         location = /status {
             return 200;
         }
@@ -426,12 +426,12 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
-            checker:report_http_status("127.0.0.1", 2112, 500, "active")
-            checker:report_http_status("127.0.0.1", 2112, 500, "active")
-            checker:report_http_status("127.0.0.1", 2112, 500, "active")
-            checker:report_http_status("127.0.0.1", 2112, 500, "active")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
+            checker:report_http_status("127.0.0.1", 2119, 500, "active")
+            checker:report_http_status("127.0.0.1", 2119, 500, "active")
+            checker:report_http_status("127.0.0.1", 2119, 500, "active")
+            checker:report_http_status("127.0.0.1", 2119, 500, "active")
+            ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- true
         }
     }
 --- request
@@ -443,4 +443,4 @@ checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
 --- no_error_log
 unhealthy HTTP increment
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+event: target status '127.0.0.1:2119' from 'true' to 'false'

--- a/t/07-report_tcp_failure.t
+++ b/t/07-report_tcp_failure.t
@@ -25,7 +25,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2120;
         location = /status {
             return 200;
         }
@@ -66,15 +66,15 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2120, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_tcp_failure("127.0.0.1", 2112, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, "active")
             checker:report_tcp_failure("127.0.0.1", 2113, nil, "passive")
-            checker:report_tcp_failure("127.0.0.1", 2112, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, "active")
             checker:report_tcp_failure("127.0.0.1", 2113, nil, "passive")
-            checker:report_tcp_failure("127.0.0.1", 2112, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, "active")
             checker:report_tcp_failure("127.0.0.1", 2113, nil, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            ngx.say(checker:get_target_status("127.0.0.1", 2120))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
     }
@@ -86,10 +86,10 @@ false
 --- error_log
 checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
-unhealthy TCP increment (1/3) for 127.0.0.1:2112
-unhealthy TCP increment (2/3) for 127.0.0.1:2112
-unhealthy TCP increment (3/3) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+unhealthy TCP increment (1/3) for 127.0.0.1:2120
+unhealthy TCP increment (2/3) for 127.0.0.1:2120
+unhealthy TCP increment (3/3) for 127.0.0.1:2120
+event: target status '127.0.0.1:2120' from 'true' to 'false'
 unhealthy TCP increment (1/3) for 127.0.0.1:2113
 unhealthy TCP increment (2/3) for 127.0.0.1:2113
 unhealthy TCP increment (3/3) for 127.0.0.1:2113
@@ -102,7 +102,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2120;
         location = /status {
             return 200;
         }
@@ -143,11 +143,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
-            checker:report_tcp_failure("127.0.0.1", 2112, nil, "active")
-            checker:report_tcp_failure("127.0.0.1", 2112, nil, "active")
-            checker:report_tcp_failure("127.0.0.1", 2112, nil, "active")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            local ok, err = checker:add_target("127.0.0.1", 2120, nil, true)
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, "active")
+            ngx.say(checker:get_target_status("127.0.0.1", 2120))  -- true
         }
     }
 --- request
@@ -159,7 +159,7 @@ checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
 --- no_error_log
 unhealthy TCP increment
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+event: target status '127.0.0.1:2120' from 'true' to 'false'
 
 
 
@@ -169,7 +169,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2120;
         location = /status {
             return 200;
         }
@@ -210,11 +210,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
-            checker:report_tcp_failure("127.0.0.1", 2112, nil, "passive")
-            checker:report_tcp_failure("127.0.0.1", 2112, nil, "passive")
-            checker:report_tcp_failure("127.0.0.1", 2112, nil, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            local ok, err = checker:add_target("127.0.0.1", 2120, nil, true)
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, "passive")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, "passive")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2120))  -- true
         }
     }
 --- request
@@ -226,4 +226,4 @@ checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
 --- no_error_log
 unhealthy TCP increment
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+event: target status '127.0.0.1:2120' from 'true' to 'false'

--- a/t/08-report_timeout.t
+++ b/t/08-report_timeout.t
@@ -25,7 +25,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2122;
         location = /status {
             return 200;
         }
@@ -68,13 +68,13 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2122, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_timeout("127.0.0.1", 2112, "active")
+            checker:report_timeout("127.0.0.1", 2122, "active")
             checker:report_timeout("127.0.0.1", 2113, "passive")
-            checker:report_timeout("127.0.0.1", 2112, "active")
+            checker:report_timeout("127.0.0.1", 2122, "active")
             checker:report_timeout("127.0.0.1", 2113, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            ngx.say(checker:get_target_status("127.0.0.1", 2122))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
     }
@@ -86,9 +86,9 @@ false
 --- error_log
 checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
-unhealthy TIMEOUT increment (1/2) for 127.0.0.1:2112
-unhealthy TIMEOUT increment (2/2) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+unhealthy TIMEOUT increment (1/2) for 127.0.0.1:2122
+unhealthy TIMEOUT increment (2/2) for 127.0.0.1:2122
+event: target status '127.0.0.1:2122' from 'true' to 'false'
 unhealthy TIMEOUT increment (1/2) for 127.0.0.1:2113
 unhealthy TIMEOUT increment (2/2) for 127.0.0.1:2113
 event: target status '127.0.0.1:2113' from 'true' to 'false'
@@ -100,7 +100,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2122;
         location = /status {
             return 200;
         }
@@ -143,11 +143,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
-            checker:report_timeout("127.0.0.1", 2112, "active")
-            checker:report_timeout("127.0.0.1", 2112, "active")
-            checker:report_timeout("127.0.0.1", 2112, "active")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            local ok, err = checker:add_target("127.0.0.1", 2122, nil, true)
+            checker:report_timeout("127.0.0.1", 2122, "active")
+            checker:report_timeout("127.0.0.1", 2122, "active")
+            checker:report_timeout("127.0.0.1", 2122, "active")
+            ngx.say(checker:get_target_status("127.0.0.1", 2122))  -- true
         }
     }
 --- request
@@ -159,7 +159,7 @@ checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
 --- no_error_log
 unhealthy TCP increment
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+event: target status '127.0.0.1:2122' from 'true' to 'false'
 
 
 
@@ -169,7 +169,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2122;
         location = /status {
             return 200;
         }
@@ -212,11 +212,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
-            checker:report_timeout("127.0.0.1", 2112, "passive")
-            checker:report_timeout("127.0.0.1", 2112, "passive")
-            checker:report_timeout("127.0.0.1", 2112, "passive")
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            local ok, err = checker:add_target("127.0.0.1", 2122, nil, true)
+            checker:report_timeout("127.0.0.1", 2122, "passive")
+            checker:report_timeout("127.0.0.1", 2122, "passive")
+            checker:report_timeout("127.0.0.1", 2122, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2122))  -- true
         }
     }
 --- request
@@ -228,4 +228,4 @@ checking healthy targets: nothing to do
 checking unhealthy targets: nothing to do
 --- no_error_log
 unhealthy TCP increment
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+event: target status '127.0.0.1:2122' from 'true' to 'false'

--- a/t/09-active_probes.t
+++ b/t/09-active_probes.t
@@ -25,7 +25,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2114;
         location = /status {
             return 500;
         }
@@ -55,9 +55,9 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, true)
             ngx.sleep(0.5) -- wait for 5x the check interval
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- false
         }
     }
 --- request
@@ -66,10 +66,10 @@ GET /t
 false
 --- error_log
 checking unhealthy targets: nothing to do
-unhealthy HTTP increment (1/3) for 127.0.0.1:2112
-unhealthy HTTP increment (2/3) for 127.0.0.1:2112
-unhealthy HTTP increment (3/3) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for 127.0.0.1:2114
+unhealthy HTTP increment (2/3) for 127.0.0.1:2114
+unhealthy HTTP increment (3/3) for 127.0.0.1:2114
+event: target status '127.0.0.1:2114' from 'true' to 'false'
 checking healthy targets: nothing to do
 
 
@@ -80,7 +80,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2114;
         location = /status {
             return 200;
         }
@@ -110,9 +110,9 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, false)
             ngx.sleep(0.5) -- wait for 5x the check interval
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- true
         }
     }
 --- request
@@ -121,10 +121,10 @@ GET /t
 true
 --- error_log
 checking healthy targets: nothing to do
-healthy SUCCESS increment (1/3) for 127.0.0.1:2112
-healthy SUCCESS increment (2/3) for 127.0.0.1:2112
-healthy SUCCESS increment (3/3) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for 127.0.0.1:2114
+healthy SUCCESS increment (2/3) for 127.0.0.1:2114
+healthy SUCCESS increment (3/3) for 127.0.0.1:2114
+event: target status '127.0.0.1:2114' from 'false' to 'true'
 checking unhealthy targets: nothing to do
 
 === TEST 3: active probes, custom http status (regression test for pre-filled defaults)
@@ -133,7 +133,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2114;
         location = /status {
             return 500;
         }
@@ -164,9 +164,9 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, true)
             ngx.sleep(0.5) -- wait for 5x the check interval
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- true
         }
     }
 --- request
@@ -177,10 +177,10 @@ true
 checking unhealthy targets: nothing to do
 --- no_error_log
 checking healthy targets: nothing to do
-unhealthy HTTP increment (1/3) for 127.0.0.1:2112
-unhealthy HTTP increment (2/3) for 127.0.0.1:2112
-unhealthy HTTP increment (3/3) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for 127.0.0.1:2114
+unhealthy HTTP increment (2/3) for 127.0.0.1:2114
+unhealthy HTTP increment (3/3) for 127.0.0.1:2114
+event: target status '127.0.0.1:2114' from 'true' to 'false'
 
 
 === TEST 4: active probes, custom http status, node failing
@@ -189,7 +189,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2114;
         location = /status {
             return 401;
         }
@@ -220,9 +220,9 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, true)
             ngx.sleep(0.5) -- wait for 5x the check interval
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
+            ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- false
         }
     }
 --- request
@@ -231,10 +231,10 @@ GET /t
 false
 --- error_log
 checking unhealthy targets: nothing to do
-unhealthy HTTP increment (1/3) for 127.0.0.1:2112
-unhealthy HTTP increment (2/3) for 127.0.0.1:2112
-unhealthy HTTP increment (3/3) for 127.0.0.1:2112
-event: target status '127.0.0.1:2112' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for 127.0.0.1:2114
+unhealthy HTTP increment (2/3) for 127.0.0.1:2114
+unhealthy HTTP increment (3/3) for 127.0.0.1:2114
+event: target status '127.0.0.1:2114' from 'true' to 'false'
 checking healthy targets: nothing to do
 
 
@@ -245,7 +245,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2114;
         location = /status {
             content_by_lua_block {
                 if ngx.req.get_headers()["Host"] == "example.com" then
@@ -281,9 +281,9 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2112, "example.com", false)
+            local ok, err = checker:add_target("127.0.0.1", 2114, "example.com", false)
             ngx.sleep(0.3) -- wait for 3x the check interval
-            ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- true
         }
     }
 --- request
@@ -291,5 +291,5 @@ GET /t
 --- response_body
 true
 --- error_log
-event: target status '127.0.0.1:2112' from 'false' to 'true'
+event: target status '127.0.0.1:2114' from 'false' to 'true'
 checking unhealthy targets: nothing to do

--- a/t/10-garbagecollect.t
+++ b/t/10-garbagecollect.t
@@ -25,7 +25,7 @@ qq{
     $::HttpConfig
 
     server {
-        listen 2112;
+        listen 2121;
         location = /status {
             return 200;
         }
@@ -61,7 +61,7 @@ qq{
                     },
                 }
             })
-            assert(checker:add_target("127.0.0.1", 2112, nil, true))
+            assert(checker:add_target("127.0.0.1", 2121, nil, true))
             local weak_table = setmetatable({ checker },{
               __mode = "v",
             })


### PR DESCRIPTION
All the tests use the same port for backend checking. It can lead to race condition when two tests using the same ports run simultaneously due to -j2