### PR TITLE
change 'type' option into 'checks.active.type' and 'checks.passive.type'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,9 @@ http {
         local checker = healthcheck.new({
             name = "testing",
             shm_name = "test_shm",
-            type = "http",
             checks = {
                 active = {
+                    type = "https",
                     http_path = "/status",
                     healthy  = {
                         interval = 2,

--- a/t/14-tls_active_probes.t
+++ b/t/14-tls_active_probes.t
@@ -32,9 +32,9 @@ __DATA__
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-                type = "https",
                 checks = {
                     active = {
+                        type = "https",
                         http_path = "/",
                         healthy  = {
                             interval = 2,
@@ -72,9 +72,9 @@ true
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-                type = "https",
                 checks = {
                     active = {
+                        type = "https",
                         http_path = "/",
                         healthy  = {
                             interval = 2,


### PR DESCRIPTION
* Move the options to a more logical place (setting "https" explicitly is more relevant to active checks)
* Adds some more flexibility (passive and active checks can have distinct types)
* Simplifies integration of https configuration in Kong (the Upstreams entity can configure the `checks` subtable only)
* Keeps the top-level `type` as a deprecated option for backward compatibility
