### PR TITLE
add new flag checks.active.https_check_certificate

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -739,7 +739,8 @@ function checker:run_single_check(ip, port, hostname)
 
   if self.checks.active.type == "https" then
     local session
-    session, err = sock:sslhandshake(nil, hostname, true)
+    session, err = sock:sslhandshake(nil, hostname,
+                                     self.checks.active.https_check_certificate)
     if not session then
       sock:close()
       return self:report_tcp_failure(ip, port, "connect", "active")
@@ -1068,7 +1069,7 @@ local function fill_in_settings(opts, defaults, ctx)
       fail(ctx, k, "invalid value")
     end
 
-    if v then
+    if v ~= nil then
       if type(v) == "table" then
         if default[1] then -- do not recurse on arrays
           obj[k] = v
@@ -1102,6 +1103,7 @@ local defaults = {
       timeout = 1,
       concurrency = 10,
       http_path = "/",
+      https_check_certificate = true,
       healthy = {
         interval = 0, -- 0 = disabled by default
         http_statuses = { 200, 302 },
@@ -1170,6 +1172,7 @@ end
 -- * `checks.active.timeout`: socket timeout for active checks (in seconds)
 -- * `checks.active.concurrency`: number of targets to check concurrently
 -- * `checks.active.http_path`: path to use in `GET` HTTP request to run on active checks
+-- * `checks.active.https_check_certificate`: boolean indicating whether to verify the HTTPS certificate
 -- * `checks.active.healthy.interval`: interval between checks for healthy targets (in seconds)
 -- * `checks.active.healthy.http_statuses`: which HTTP statuses to consider a success
 -- * `checks.active.healthy.successes`: number of successes to consider a target healthy

--- a/t/14-tls_active_probes.t
+++ b/t/14-tls_active_probes.t
@@ -98,3 +98,44 @@ GET /t
 false
 --- timeout
 15
+
+=== TEST 3: active probes, accept invalid cert when disabling check
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+        lua_ssl_verify_depth 2;
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        type = "https",
+                        https_check_certificate = false,
+                        http_path = "/",
+                        healthy  = {
+                            interval = 2,
+                            successes = 2,
+                        },
+                        unhealthy  = {
+                            interval = 2,
+                            tcp_failures = 2,
+                        }
+                    },
+                }
+            })
+            local ok, err = checker:add_target("104.154.89.105", 443, "wrong.host.badssl.com", false)
+            ngx.sleep(8) -- wait for 4x the check interval
+            ngx.say(checker:get_target_status("104.154.89.105", 443))  -- true
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+--- timeout
+15


### PR DESCRIPTION
Adds an option to disable HTTPS certificate verification, setting
`checks.active.https_check_certificate = false` in the configuration.
It remains true by default.

Includes a test.