### PR TITLE
Fix the issue: multi kong woker processes will premature trigger other woker processes's event callback

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1267,12 +1267,6 @@ function _M.new(opts)
   -- register for events, and directly after load initial target list
   -- order is important!
   do
-    self.ev_callback = function(data, event)
-      -- just a wrapper to be able to access `self` as a closure
-      return self:event_handler(event, data.ip, data.port, data.hostname)
-    end
-    worker_events.register_weak(self.ev_callback, self.EVENT_SOURCE)
-
     -- Lock the list, in case it is being cleared by another worker
     local ok, err = locking_target_list(self, function(target_list)
 
@@ -1295,6 +1289,12 @@ function _M.new(opts)
     if not ok then
       self:log(ERR, "Error loading initial target list: ", err)
     end
+	
+	self.ev_callback = function(data, event)
+      -- just a wrapper to be able to access `self` as a closure
+      return self:event_handler(event, data.ip, data.port, data.hostname)
+    end
+    worker_events.register_weak(self.ev_callback, self.EVENT_SOURCE)
 
     -- handle events to sync up in case there was a change by another worker
     worker_events:poll()

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1289,8 +1289,8 @@ function _M.new(opts)
     if not ok then
       self:log(ERR, "Error loading initial target list: ", err)
     end
-	
-	self.ev_callback = function(data, event)
+
+    self.ev_callback = function(data, event)
       -- just a wrapper to be able to access `self` as a closure
       return self:event_handler(event, data.ip, data.port, data.hostname)
     end


### PR DESCRIPTION
Fix the issue: When restart kong process, the concurrent worker processes load targets, and premature trigger other workers's event callback, and result in the event_handler method error at line 925: the targets is nil when index it's ip field. The issue I commited at "Kong" project: [https://github.com/Kong/kong/issues/4453](https://github.com/Kong/kong/issues/4453)