### PR TITLE
refactor(log) display correct log line numbers

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1011,7 +1011,7 @@ end
 -- Log a message specific to this checker
 -- @param level standard ngx log level constant
 function checker:log(level, ...)
-  ngx_log(level, worker_color(self.LOG_PREFIX), ...)
+  return ngx_log(level, self.LOG_PREFIX, ...)
 end
 
 
@@ -1287,7 +1287,7 @@ function _M.new(opts)
   self.PERIODIC_LOCK    = SHM_PREFIX .. self.name .. ":period_lock:"
   -- prepare constants
   self.EVENT_SOURCE     = EVENT_SOURCE_PREFIX .. " [" .. self.name .. "]"
-  self.LOG_PREFIX       = LOG_PREFIX .. "(" .. self.name .. ") "
+  self.LOG_PREFIX       = worker_color(LOG_PREFIX .. "(" .. self.name .. ") ")
 
   -- register for events, and directly after load initial target list
   -- order is important!


### PR DESCRIPTION
use a tail call, to cause LuaJIT to report the caller's line number, instead of the log function line number.

Additionally move a function out of the log function to save a few cpu cycles