### PR TITLE
feat(healthcheck) track host status by ip+port+hostname+custom hostname

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ http {
             }
         })
 
-        local ok, err = checker:add_target("127.0.0.1", 8080, "example.com", false)
+        local ok, err = checker:add_target("127.0.0.1", 8080, "example.com", "example", false)
 
         local handler = function(target, eventname, sourcename, pid)
             ngx.log(ngx.DEBUG,"Event from: ", sourcename)
@@ -88,11 +88,16 @@ for the complete API.
 
 Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
-### 1.0.x (unreleased)
+### 2.0.0 (23-Sep-2019)
+
+ * BREAKING: all API functions related to hosts require a `custom_hostname`
+   argument now. This change makes it possible to track different server names
+   that resolve to the same IP, port, and hostname combination.
  * Fix: log error on SSL Handshake failure
    [#28](https://github.com/Kong/lua-resty-healthcheck/pull/28);
    
 ### 1.0.0 (05-Jul-2019)
+
  * BREAKING: all API functions related to hosts require a `hostname` argument
    now. This way different hostnames listening on the same IP and ports
    combination do not have an effect on each other.
@@ -147,7 +152,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 ## Copyright and License
 
 ```
-Copyright 2017-2018 Kong Inc.
+Copyright 2017-2019 Kong Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/rockspecs/lua-resty-healthcheck-2.0.0-1.rockspec
+++ b/rockspecs/lua-resty-healthcheck-2.0.0-1.rockspec
@@ -1,0 +1,27 @@
+package = "lua-resty-healthcheck"
+version = "2.0.0-1"
+source = {
+   url = "https://github.com/Kong/lua-resty-healthcheck/archive/2.0.0.tar.gz",
+   tag = "2.0.0",
+   dir = "lua-resty-healthcheck-2.0.0"
+}
+description = {
+   summary = "Healthchecks for OpenResty to check upstream service status",
+   detailed = [[
+      lua-resty-healthcheck is a module that can check upstream service
+      availability by sending requests and validating responses at timed
+      intervals.
+   ]],
+   homepage = "https://github.com/Kong/lua-resty-healthcheck",
+   license = "Apache 2.0"
+}
+dependencies = {
+   "lua-resty-worker-events >= 0.3.2"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["resty.healthcheck"] = "lib/resty/healthcheck.lua",
+      ["resty.healthcheck.utils"] = "lib/resty/healthcheck/utils.lua"
+   }
+}

--- a/t/02-add_target.t
+++ b/t/02-add_target.t
@@ -40,7 +40,7 @@ __DATA__
                 }
             })
             ngx.sleep(0.2) -- wait twice the interval
-            local ok, err = checker:add_target("127.0.0.1", 11111, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 11111, nil, nil, false)
             ngx.say(ok)
             ngx.sleep(0.2) -- wait twice the interval
         }
@@ -93,7 +93,7 @@ qq{
                 }
             })
             ngx.sleep(0.2) -- wait twice the interval
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, nil, true)
             ngx.say(ok)
             ngx.sleep(0.2) -- wait twice the interval
         }
@@ -149,8 +149,8 @@ qq{
                 }
             })
             ngx.sleep(0.2) -- wait twice the interval
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2113, nil, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2113, nil, nil, false)
             ngx.say(ok)
             ngx.sleep(0.2) -- wait twice the interval
         }

--- a/t/03-get_target_status.t
+++ b/t/03-get_target_status.t
@@ -63,7 +63,7 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2115, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2115, nil, nil, true)
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- true
             checker:report_tcp_failure("127.0.0.1", 2115)
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- false

--- a/t/04-report_success.t
+++ b/t/04-report_success.t
@@ -66,14 +66,14 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2116, nil, false)
-            local ok, err = checker:add_target("127.0.0.1", 2118, nil, false)
-            checker:report_success("127.0.0.1", 2116, nil, "active")
-            checker:report_success("127.0.0.1", 2118, nil, "passive")
-            checker:report_success("127.0.0.1", 2116, nil, "active")
-            checker:report_success("127.0.0.1", 2118, nil, "passive")
-            checker:report_success("127.0.0.1", 2116, nil, "active")
-            checker:report_success("127.0.0.1", 2118, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2116, nil, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2118, nil, nil, false)
+            checker:report_success("127.0.0.1", 2116, nil, nil, "active")
+            checker:report_success("127.0.0.1", 2118, nil, nil, "passive")
+            checker:report_success("127.0.0.1", 2116, nil, nil, "active")
+            checker:report_success("127.0.0.1", 2118, nil, nil, "passive")
+            checker:report_success("127.0.0.1", 2116, nil, nil, "active")
+            checker:report_success("127.0.0.1", 2118, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- true
         }
@@ -143,14 +143,14 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2116, nil, false)
-            local ok, err = checker:add_target("127.0.0.1", 2118, nil, false)
-            checker:report_success("127.0.0.1", 2116, nil, "active")
-            checker:report_success("127.0.0.1", 2118, nil, "passive")
-            checker:report_success("127.0.0.1", 2116, nil, "active")
-            checker:report_success("127.0.0.1", 2118, nil, "passive")
-            checker:report_success("127.0.0.1", 2116, nil, "active")
-            checker:report_success("127.0.0.1", 2118, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2116, nil, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2118, nil, nil, false)
+            checker:report_success("127.0.0.1", 2116, nil, nil, "active")
+            checker:report_success("127.0.0.1", 2118, nil, nil, "passive")
+            checker:report_success("127.0.0.1", 2116, nil, nil, "active")
+            checker:report_success("127.0.0.1", 2118, nil, nil, "passive")
+            checker:report_success("127.0.0.1", 2116, nil, nil, "active")
+            checker:report_success("127.0.0.1", 2118, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- true
         }
@@ -219,10 +219,10 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2116, nil, false)
-            checker:report_success("127.0.0.1", 2116, nil, "active")
-            checker:report_success("127.0.0.1", 2116, nil, "active")
-            checker:report_success("127.0.0.1", 2116, nil, "active")
+            local ok, err = checker:add_target("127.0.0.1", 2116, nil, nil, false)
+            checker:report_success("127.0.0.1", 2116, nil, nil, "active")
+            checker:report_success("127.0.0.1", 2116, nil, nil, "active")
+            checker:report_success("127.0.0.1", 2116, nil, nil, "active")
             ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- false
         }
     }
@@ -283,10 +283,10 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2118, nil, false)
-            checker:report_success("127.0.0.1", 2118, nil, "passive")
-            checker:report_success("127.0.0.1", 2118, nil, "passive")
-            checker:report_success("127.0.0.1", 2118, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2118, nil, nil, false)
+            checker:report_success("127.0.0.1", 2118, nil, nil, "passive")
+            checker:report_success("127.0.0.1", 2118, nil, nil, "passive")
+            checker:report_success("127.0.0.1", 2118, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2118, nil))  -- false
         }
     }

--- a/t/05-report_failure.t
+++ b/t/05-report_failure.t
@@ -66,14 +66,14 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2117, nil, true)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_failure("127.0.0.1", 2117, nil, "active")
-            checker:report_failure("127.0.0.1", 2113, nil, "passive")
-            checker:report_failure("127.0.0.1", 2117, nil, "active")
-            checker:report_failure("127.0.0.1", 2113, nil, "passive")
-            checker:report_failure("127.0.0.1", 2117, nil, "active")
-            checker:report_failure("127.0.0.1", 2113, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2117, nil, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2113, nil, nil, true)
+            checker:report_failure("127.0.0.1", 2117, nil, nil, "active")
+            checker:report_failure("127.0.0.1", 2113, nil, nil, "passive")
+            checker:report_failure("127.0.0.1", 2117, nil, nil, "active")
+            checker:report_failure("127.0.0.1", 2113, nil, nil, "passive")
+            checker:report_failure("127.0.0.1", 2117, nil, nil, "active")
+            checker:report_failure("127.0.0.1", 2113, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2117, nil))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113, nil))  -- false
         }
@@ -143,14 +143,14 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2117, nil, true)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_failure("127.0.0.1", 2117, nil, "active")
-            checker:report_failure("127.0.0.1", 2113, nil, "passive")
-            checker:report_failure("127.0.0.1", 2117, nil, "active")
-            checker:report_failure("127.0.0.1", 2113, nil, "passive")
-            checker:report_failure("127.0.0.1", 2117, nil, "active")
-            checker:report_failure("127.0.0.1", 2113, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2117, nil, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2113, nil, nil, true)
+            checker:report_failure("127.0.0.1", 2117, nil, nil, "active")
+            checker:report_failure("127.0.0.1", 2113, nil, nil, "passive")
+            checker:report_failure("127.0.0.1", 2117, nil, nil, "active")
+            checker:report_failure("127.0.0.1", 2113, nil, nil, "passive")
+            checker:report_failure("127.0.0.1", 2117, nil, nil, "active")
+            checker:report_failure("127.0.0.1", 2113, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2117, nil))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113, nil))  -- false
         }
@@ -218,14 +218,14 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2117, nil, true)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_failure("127.0.0.1", 2117, nil, "active")
-            checker:report_failure("127.0.0.1", 2113, nil, "passive")
-            checker:report_failure("127.0.0.1", 2117, nil, "active")
-            checker:report_failure("127.0.0.1", 2113, nil, "passive")
-            checker:report_failure("127.0.0.1", 2117, nil, "active")
-            checker:report_failure("127.0.0.1", 2113, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2117, nil, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2113, nil, nil, true)
+            checker:report_failure("127.0.0.1", 2117, nil, nil, "active")
+            checker:report_failure("127.0.0.1", 2113, nil, nil, "passive")
+            checker:report_failure("127.0.0.1", 2117, nil, nil, "active")
+            checker:report_failure("127.0.0.1", 2113, nil, nil, "passive")
+            checker:report_failure("127.0.0.1", 2117, nil, nil, "active")
+            checker:report_failure("127.0.0.1", 2113, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2117, nil))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2113, nil))  -- true
         }

--- a/t/06-report_http_status.t
+++ b/t/06-report_http_status.t
@@ -66,14 +66,14 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
-            checker:report_http_status("127.0.0.1", 2113, nil, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
-            checker:report_http_status("127.0.0.1", 2113, nil, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
-            checker:report_http_status("127.0.0.1", 2113, nil, 500, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2113, nil, nil, true)
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "active")
+            checker:report_http_status("127.0.0.1", 2113, nil, nil, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "active")
+            checker:report_http_status("127.0.0.1", 2113, nil, nil, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "active")
+            checker:report_http_status("127.0.0.1", 2113, nil, nil, 500, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
@@ -144,16 +144,16 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2119, nil, false)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, false)
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
-            checker:report_http_status("127.0.0.1", 2113, nil, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
-            checker:report_http_status("127.0.0.1", 2113, nil, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
-            checker:report_http_status("127.0.0.1", 2113, nil, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
-            checker:report_http_status("127.0.0.1", 2113, nil, 200, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2113, nil, nil, false)
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "active")
+            checker:report_http_status("127.0.0.1", 2113, nil, nil, 200, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "active")
+            checker:report_http_status("127.0.0.1", 2113, nil, nil, 200, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "active")
+            checker:report_http_status("127.0.0.1", 2113, nil, nil, 200, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "active")
+            checker:report_http_status("127.0.0.1", 2113, nil, nil, 200, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- true
         }
@@ -225,11 +225,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2119, nil, false)
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, nil, false)
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2119, nil))  -- false
         }
     }
@@ -292,11 +292,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2119, nil, false)
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
-            checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, nil, false)
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "active")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 200, "active")
             ngx.say(checker:get_target_status("127.0.0.1", 2119, nil))  -- false
         }
     }
@@ -359,11 +359,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, nil, true)
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- true
         }
     }
@@ -426,11 +426,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
-            checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, nil, true)
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "active")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "active")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "active")
+            checker:report_http_status("127.0.0.1", 2119, nil, nil, 500, "active")
             ngx.say(checker:get_target_status("127.0.0.1", 2119, nil))  -- true
         }
     }

--- a/t/07-report_tcp_failure.t
+++ b/t/07-report_tcp_failure.t
@@ -66,14 +66,14 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2120, nil, true)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
-            checker:report_tcp_failure("127.0.0.1", 2113, nil, nil, "passive")
-            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
-            checker:report_tcp_failure("127.0.0.1", 2113, nil, nil, "passive")
-            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
-            checker:report_tcp_failure("127.0.0.1", 2113, nil, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2120, nil, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2113, nil, nil, true)
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2113, nil, nil, nil, "passive")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2113, nil, nil, nil, "passive")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2113, nil, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2120))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
@@ -143,10 +143,10 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2120, nil, true)
-            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
-            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
-            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
+            local ok, err = checker:add_target("127.0.0.1", 2120, nil, nil, true)
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, nil, "active")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, nil, "active")
             ngx.say(checker:get_target_status("127.0.0.1", 2120))  -- true
         }
     }
@@ -210,10 +210,10 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2120, nil, true)
-            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "passive")
-            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "passive")
-            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2120, nil, nil, true)
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, nil, "passive")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, nil, "passive")
+            checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2120))  -- true
         }
     }

--- a/t/08-report_timeout.t
+++ b/t/08-report_timeout.t
@@ -68,12 +68,12 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2122, nil, true)
-            local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
-            checker:report_timeout("127.0.0.1", 2122, nil, "active")
-            checker:report_timeout("127.0.0.1", 2113, nil, "passive")
-            checker:report_timeout("127.0.0.1", 2122, nil, "active")
-            checker:report_timeout("127.0.0.1", 2113, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2122, nil, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2113, nil, nil, true)
+            checker:report_timeout("127.0.0.1", 2122, nil, nil, nil, "active")
+            checker:report_timeout("127.0.0.1", 2113, nil, nil, nil, "passive")
+            checker:report_timeout("127.0.0.1", 2122, nil, nil, nil, "active")
+            checker:report_timeout("127.0.0.1", 2113, nil, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2122))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
@@ -143,10 +143,10 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2122, nil, true)
-            checker:report_timeout("127.0.0.1", 2122, nil, "active")
-            checker:report_timeout("127.0.0.1", 2122, nil, "active")
-            checker:report_timeout("127.0.0.1", 2122, nil, "active")
+            local ok, err = checker:add_target("127.0.0.1", 2122, nil, nil, true)
+            checker:report_timeout("127.0.0.1", 2122, nil, nil, "active")
+            checker:report_timeout("127.0.0.1", 2122, nil, nil, "active")
+            checker:report_timeout("127.0.0.1", 2122, nil, nil, "active")
             ngx.say(checker:get_target_status("127.0.0.1", 2122))  -- true
         }
     }
@@ -212,10 +212,10 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2122, nil, true)
-            checker:report_timeout("127.0.0.1", 2122, nil, "passive")
-            checker:report_timeout("127.0.0.1", 2122, nil, "passive")
-            checker:report_timeout("127.0.0.1", 2122, nil, "passive")
+            local ok, err = checker:add_target("127.0.0.1", 2122, nil, nil, true)
+            checker:report_timeout("127.0.0.1", 2122, nil, nil, "passive")
+            checker:report_timeout("127.0.0.1", 2122, nil, nil, "passive")
+            checker:report_timeout("127.0.0.1", 2122, nil, nil, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2122))  -- true
         }
     }

--- a/t/09-active_probes.t
+++ b/t/09-active_probes.t
@@ -55,7 +55,7 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2114, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, nil, true)
             ngx.sleep(0.5) -- wait for 5x the check interval
             ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- false
         }
@@ -110,7 +110,7 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2114, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, nil, false)
             ngx.sleep(0.5) -- wait for 5x the check interval
             ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- true
         }
@@ -164,7 +164,7 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2114, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, nil, true)
             ngx.sleep(0.5) -- wait for 5x the check interval
             ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- true
         }
@@ -220,7 +220,7 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2114, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, nil, true)
             ngx.sleep(0.5) -- wait for 5x the check interval
             ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- false
         }
@@ -281,7 +281,7 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2114, "example.com", false)
+            local ok, err = checker:add_target("127.0.0.1", 2114, "example.com", nil, false)
             ngx.sleep(0.3) -- wait for 3x the check interval
             ngx.say(checker:get_target_status("127.0.0.1", 2114, "example.com"))  -- true
         }
@@ -324,7 +324,7 @@ qq{
                 }
             })
             -- Note: no http server configured, so port 2114 remains unanswered
-            local ok, err = checker:add_target("127.0.0.1", 2114, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, nil, true)
             ngx.sleep(0.5) -- wait for 5x the check interval
             ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- false
         }
@@ -379,7 +379,7 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2114, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2114, nil, nil, false)
             ngx.sleep(0.5) -- wait for 5x the check interval
             ngx.say(checker:get_target_status("127.0.0.1", 2114))  -- true
         }

--- a/t/10-garbagecollect.t
+++ b/t/10-garbagecollect.t
@@ -61,7 +61,7 @@ qq{
                     },
                 }
             })
-            assert(checker:add_target("127.0.0.1", 2121, nil, true))
+            assert(checker:add_target("127.0.0.1", 2121, nil, nil, true))
             local weak_table = setmetatable({ checker },{
               __mode = "v",
             })

--- a/t/11-clear.t
+++ b/t/11-clear.t
@@ -41,7 +41,7 @@ __DATA__
             }
             local checker1 = healthcheck.new(config)
             for i = 1, 10 do
-                checker1:add_target("127.0.0.1", 10000 + i, nil, false)
+                checker1:add_target("127.0.0.1", 10000 + i, nil, nil, false)
             end
             ngx.sleep(0.2) -- wait twice the interval
             checker1:clear()
@@ -97,7 +97,7 @@ initial target list (11 targets)
             local checker1 = healthcheck.new(config)
             local checker2 = healthcheck.new(config)
             for i = 1, 10 do
-                checker1:add_target("127.0.0.1", 20000 + i, nil, false)
+                checker1:add_target("127.0.0.1", 20000 + i, nil, nil, false)
             end
             checker2:clear()
             ngx.sleep(0.2) -- wait twice the interval
@@ -150,10 +150,10 @@ qq{
                 }
             }
             local checker1 = healthcheck.new(config)
-            checker1:add_target("127.0.0.1", 21120, nil, true)
+            checker1:add_target("127.0.0.1", 21120, nil, nil, true)
             ngx.sleep(0.3) -- wait 1.5x the interval
             checker1:clear()
-            checker1:add_target("127.0.0.1", 21120, nil, true)
+            checker1:add_target("127.0.0.1", 21120, nil, nil, true)
             ngx.sleep(0.3) -- wait 1.5x the interval
             ngx.say(true)
         }

--- a/t/12-set_target_status.t
+++ b/t/12-set_target_status.t
@@ -33,11 +33,11 @@ qq{
                 shm_name = "test_shm",
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, nil, true)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
-            checker:set_target_status("127.0.0.1", 2112, nil, false)
+            checker:set_target_status("127.0.0.1", 2112, nil, nil, false)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
-            checker:set_target_status("127.0.0.1", 2112, nil, true)
+            checker:set_target_status("127.0.0.1", 2112, nil, nil, true)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
         }
     }
@@ -71,12 +71,12 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, nil, true)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
-            checker:report_http_status("127.0.0.1", 2112, nil, 500)
-            checker:report_http_status("127.0.0.1", 2112, nil, 500)
+            checker:report_http_status("127.0.0.1", 2112, nil, nil, 500)
+            checker:report_http_status("127.0.0.1", 2112, nil, nil, 500)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
-            checker:set_target_status("127.0.0.1", 2112, nil, true)
+            checker:set_target_status("127.0.0.1", 2112, nil, nil, true)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
         }
     }
@@ -113,13 +113,13 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, nil, true)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
-            checker:report_http_status("127.0.0.1", 2112, nil, 500)
-            checker:set_target_status("127.0.0.1", 2112, nil, true)
-            checker:report_http_status("127.0.0.1", 2112, nil, 500)
+            checker:report_http_status("127.0.0.1", 2112, nil, nil, 500)
+            checker:set_target_status("127.0.0.1", 2112, nil, nil, true)
+            checker:report_http_status("127.0.0.1", 2112, nil, nil, 500)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
-            checker:report_http_status("127.0.0.1", 2112, nil, 500)
+            checker:report_http_status("127.0.0.1", 2112, nil, nil, 500)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
         }
     }
@@ -129,7 +129,7 @@ GET /t
 true
 true
 false
-=== TEST 3: set_target_status() resets the success counters
+=== TEST 4: set_target_status() resets the success counters
 --- http_config eval
 qq{
     $::HttpConfig
@@ -156,14 +156,14 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
-            checker:set_target_status("127.0.0.1", 2112, nil, false)
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, nil, true)
+            checker:set_target_status("127.0.0.1", 2112, nil, nil, false)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
-            checker:report_http_status("127.0.0.1", 2112, nil, 200)
-            checker:set_target_status("127.0.0.1", 2112, nil, false)
-            checker:report_http_status("127.0.0.1", 2112, nil, 200)
+            checker:report_http_status("127.0.0.1", 2112, nil, nil, 200)
+            checker:set_target_status("127.0.0.1", 2112, nil, nil, false)
+            checker:report_http_status("127.0.0.1", 2112, nil, nil, 200)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
-            checker:report_http_status("127.0.0.1", 2112, nil, 200)
+            checker:report_http_status("127.0.0.1", 2112, nil, nil, 200)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
         }
     }

--- a/t/13-integration.t
+++ b/t/13-integration.t
@@ -65,7 +65,7 @@ qq{
                 }
             })
 
-            local ok, err = checker:add_target(host, port, nil, true)
+            local ok, err = checker:add_target(host, port, nil, nil, true)
 
             -- S = successes counter
             -- F = http_failures counter
@@ -111,34 +111,34 @@ qq{
             -- and compares the results given by the library with a simple simulation
             -- that implements the specified behavior.
             local function run_test_case(case)
-                assert(checker:set_target_status(host, port, nil, true))
+                assert(checker:set_target_status(host, port, nil, nil, true))
                 local i = 1
                 local s, f, t, o = 0, 0, 0, 0
                 local mode = true
                 for c in case:gmatch(".") do
                     if c == "S" then
-                        checker:report_http_status(host, port, nil, 200, "passive")
+                        checker:report_http_status(host, port, nil, nil, 200, "passive")
                         s = s + 1
                         f, t, o = 0, 0, 0
                         if s == 2 then
                             mode = true
                         end
                     elseif c == "F" then
-                        checker:report_http_status(host, port, nil, 500, "passive")
+                        checker:report_http_status(host, port, nil, nil, 500, "passive")
                         f = f + 1
                         s = 0
                         if f == 2 then
                             mode = false
                         end
                     elseif c == "T" then
-                        checker:report_tcp_failure(host, port, nil, "read", "passive")
+                        checker:report_tcp_failure(host, port, nil, nil, "read", "passive")
                         t = t + 1
                         s = 0
                         if t == 2 then
                             mode = false
                         end
                     elseif c == "O" then
-                        checker:report_timeout(host, port, nil, "passive")
+                        checker:report_timeout(host, port, nil, nil, "passive")
                         o = o + 1
                         s = 0
                         if o == 2 then
@@ -150,7 +150,7 @@ qq{
                     --ngx.say(case, ": ", c, " ", string.format("%08x", ctr), " ", state)
                     --ngx.log(ngx.DEBUG, case, ": ", c, " ", string.format("%08x", ctr), " ", state)
 
-                    if checker:get_target_status(host, port, nil) ~= mode then
+                    if checker:get_target_status(host, port, nil, nil) ~= mode then
                         ngx.say("failed: ", case, " step ", i, " expected ", mode)
                         return false
                     end

--- a/t/14-tls_active_probes.t
+++ b/t/14-tls_active_probes.t
@@ -47,7 +47,7 @@ __DATA__
                     },
                 }
             })
-            local ok, err = checker:add_target("104.154.89.105", 443, "badssl.com", false)
+            local ok, err = checker:add_target("104.154.89.105", 443, "badssl.com", nil, false)
             ngx.sleep(8) -- wait for 4x the check interval
             ngx.say(checker:get_target_status("104.154.89.105", 443, "badssl.com"))  -- true
         }
@@ -87,7 +87,7 @@ true
                     },
                 }
             })
-            local ok, err = checker:add_target("104.154.89.105", 443, "wrong.host.badssl.com", true)
+            local ok, err = checker:add_target("104.154.89.105", 443, "wrong.host.badssl.com", nil, true)
             ngx.sleep(8) -- wait for 4x the check interval
             ngx.say(checker:get_target_status("104.154.89.105", 443, "wrong.host.badssl.com"))  -- false
         }
@@ -128,7 +128,7 @@ false
                     },
                 }
             })
-            local ok, err = checker:add_target("104.154.89.105", 443, "wrong.host.badssl.com", false)
+            local ok, err = checker:add_target("104.154.89.105", 443, "wrong.host.badssl.com", nil, false)
             ngx.sleep(8) -- wait for 4x the check interval
             ngx.say(checker:get_target_status("104.154.89.105", 443, "wrong.host.badssl.com"))  -- true
         }

--- a/t/15-get_virtualhost_target_status.t
+++ b/t/15-get_virtualhost_target_status.t
@@ -3,7 +3,7 @@ use Cwd qw(cwd);
 
 workers(1);
 
-plan tests => repeat_each() * (blocks() * 5) + 2;
+plan tests => repeat_each() * (blocks() * 5) + 3;
 
 my $pwd = cwd();
 
@@ -56,13 +56,13 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2115, "ahostname", true)
-            local ok, err = checker:add_target("127.0.0.1", 2115, "otherhostname", true)
+            local ok, err = checker:add_target("127.0.0.1", 2115, "ahostname", nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2115, "otherhostname", nil, true)
             ngx.say(checker:get_target_status("127.0.0.1", 2115, "ahostname"))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2115, "otherhostname"))  -- true
-            checker:report_http_status("127.0.0.1", 2115, "otherhostname", 500, "passive")
+            checker:report_http_status("127.0.0.1", 2115, "otherhostname", nil, 500, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2115, "otherhostname"))  -- true
-            checker:report_http_status("127.0.0.1", 2115, "otherhostname", 500, "passive")
+            checker:report_http_status("127.0.0.1", 2115, "otherhostname", nil, 500, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2115, "otherhostname"))  -- false
             checker:report_success("127.0.0.1", 2115, "otherhostname")
             ngx.say(checker:get_target_status("127.0.0.1", 2115, "otherhostname"))  -- true
@@ -130,11 +130,11 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2116, "ahostname", true)
-            local ok, err = checker:add_target("127.0.0.1", 2116, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2116, "ahostname", nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2116, nil, nil, true)
             ngx.say(checker:get_target_status("127.0.0.1", 2116, "ahostname"))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- true
-            checker:report_http_status("127.0.0.1", 2116, nil, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2116, nil, nil, 500, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2116, "ahostname"))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2116)) -- false
         }
@@ -195,8 +195,8 @@ qq{
                     },
                 }
             })
-            local ok, err = checker:add_target("127.0.0.1", 2117, "healthyserver", true)
-            local ok, err = checker:add_target("127.0.0.1", 2117, "unhealthyserver", true)
+            local ok, err = checker:add_target("127.0.0.1", 2117, "healthyserver", nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2117, "unhealthyserver", nil, true)
             ngx.sleep(0.5) -- wait for 5x the check interval
             ngx.say(checker:get_target_status("127.0.0.1", 2117, "healthyserver"))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2117, "unhealthyserver"))  -- false
@@ -258,18 +258,18 @@ qq{
                 }
             })
             ngx.sleep(0.1) -- wait for initial timers to run once
-            local ok, err = checker:add_target("127.0.0.1", 2118, "127.0.0.1", true)
-            local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2118, "127.0.0.1", nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, nil, true)
             ngx.say(checker:get_target_status("127.0.0.1", 2118, "127.0.0.1"))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2119, "127.0.0.1"))  -- true
-            checker:report_http_status("127.0.0.1", 2118, nil, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2118, nil, nil, 500, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2118, "127.0.0.1"))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2119, "127.0.0.1"))  -- true
-            checker:report_http_status("127.0.0.1", 2119, "127.0.0.1", 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, "127.0.0.1", nil, 500, "passive")
             ngx.say(checker:get_target_status("127.0.0.1", 2118, "127.0.0.1"))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- false
@@ -296,3 +296,81 @@ unhealthy HTTP increment (1/1) for '(127.0.0.1:2118)'
 event: target status '(127.0.0.1:2118)' from 'true' to 'false'
 unhealthy HTTP increment (1/1) for '127.0.0.1(127.0.0.1:2119)'
 event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'
+
+
+=== TEST 5: get_target_status() reports proper status for different custom hostnames
+--- http_config eval
+qq{
+    $::HttpConfig
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        http_path = "/status",
+                        healthy  = {
+                            interval = 999, -- we don't want active checks
+                            successes = 1,
+                        },
+                        unhealthy  = {
+                            interval = 999, -- we don't want active checks
+                            tcp_failures = 1,
+                            http_failures = 1,
+                        }
+                    },
+                    passive = {
+                        healthy  = {
+                            successes = 1,
+                        },
+                        unhealthy  = {
+                            tcp_failures = 1,
+                            http_failures = 1,
+                        }
+                    }
+                }
+            })
+            ngx.sleep(0.1) -- wait for initial timers to run once
+            local ok, err = checker:add_target("127.0.0.1", 2118, "localhost", nil, true)
+            local ok, err = checker:add_target("127.0.0.1", 2118, "localhost", "custom", true)
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost"))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost", "custom"))  -- true
+            checker:report_http_status("127.0.0.1", 2118, "localhost", nil, 500, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost", nil))  -- false
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost", "custom"))  -- true
+            checker:report_http_status("127.0.0.1", 2118, "localhost", "custom", 500, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost", nil))  -- false
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost", "custom"))  -- false
+            checker:report_http_status("127.0.0.1", 2118, "localhost", nil, 200, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost", nil))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost", "custom"))  -- false
+            checker:report_http_status("127.0.0.1", 2118, "localhost", "custom", 200, "passive")
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost", nil))  -- true
+            ngx.say(checker:get_target_status("127.0.0.1", 2118, "localhost", "custom"))  -- true
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+true
+false
+true
+false
+false
+true
+false
+true
+true
+--- error_log
+unhealthy HTTP increment (1/1) for 'localhost(127.0.0.1:2118)'
+event: target status 'localhost(127.0.0.1:2118)' from 'true' to 'false'
+unhealthy HTTP increment (1/1) for 'localhost(as custom)(127.0.0.1:2118)'
+target status 'localhost (as custom) (127.0.0.1:2118)' from 'true' to 'false'
+


### PR DESCRIPTION
This change makes it possible to track different server names that resolve to the same IP, port, and hostname combination.