### PR TITLE
fix(healthcheck) fail hard when initial locking_target_list failed

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1324,7 +1324,9 @@ function _M.new(opts)
       return true
     end)
     if not ok then
-      self:log(ERR, "Error loading initial target list: ", err)
+      -- locking failed, we don't protect `targets` of being nil in other places
+      -- so consider this as not recoverable
+      return nil, "Error loading initial target list: " .. err
     end
 
     self.ev_callback = function(data, event)


### PR DESCRIPTION
Since we didn't protect nil ptr of `targets` in other places in this library, error
on `locking_target_list` which makes `targets` remain `nil` should be considered
unrecoverable failure.

See also https://github.com/Kong/kong/issues/5189