### PR TITLE
avoid `self.targets` is nil.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 * feature: added a status version field [#54](https://github.com/Kong/lua-resty-healthcheck/pull/54)
 * feature: add headers for probe request [#54](https://github.com/Kong/lua-resty-healthcheck/pull/54)
 * fix: exit early when reloading during a probe [#47](https://github.com/Kong/lua-resty-healthcheck/pull/47)
+* fix: prevent target-list from being nil, due to async behaviour [#44](https://github.com/Kong/lua-resty-healthcheck/pull/44)
 
 ### 1.3.0 (17-Jun-2020)
 

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1398,7 +1398,7 @@ function _M.new(opts)
   end
 
   -- other properties
-  self.targets = nil     -- list of targets, initially loaded, maintained by events
+  self.targets = {}     -- list of targets, initially loaded, maintained by events
   self.events = nil      -- hash table with supported events (prevent magic strings)
   self.stopping = true   -- flag to indicate to timers to stop checking
   self.timer_count = 0   -- number of running timers


### PR DESCRIPTION
when two worker create `checker`, `worker-0` first created and add target success, then `worker-1` creating, when `worker-1` call `worker_events:poll()` in line 1408, raise crash.
`self.targets` init with empty table avoid this.