### PR TITLE
add worker exiting judge

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 * fix: makefile; make install
 * feature: added a status version field [#54](https://github.com/Kong/lua-resty-healthcheck/pull/54)
 * feature: add headers for probe request [#54](https://github.com/Kong/lua-resty-healthcheck/pull/54)
+* fix: exit early when reloading during a probe [#47](https://github.com/Kong/lua-resty-healthcheck/pull/47)
 
 ### 1.3.0 (17-Jun-2020)
 

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -38,6 +38,7 @@ local resty_lock = require ("resty.lock")
 local re_find = ngx.re.find
 local bit = require("bit")
 local ngx_now = ngx.now
+local ngx_worker_exiting = ngx.worker.exiting
 local ssl = require("ngx.ssl")
 
 -- constants
@@ -903,6 +904,10 @@ end
 -- executes a work package (a list of checks) sequentially
 function checker:run_work_package(work_package)
   for _, work_item in ipairs(work_package) do
+    if ngx_worker_exiting() then
+      self:log(DEBUG, "worker exting, skip check")
+      break
+    end
     self:log(DEBUG, "Checking ", work_item.hostname or "", " ",
                     work_item.hostheader and "(host header: ".. work_item.hostheader .. ")"
                     or "", work_item.ip, ":", work_item.port,


### PR DESCRIPTION
when reload nginx, if healthcheck lib doing `active_check_targets`, old nginx quit after checking all target. add `ngx.worker.exiting` check in `run_work_package` can fast quit.