### PR TITLE
Added support for https_sni in healthcheck.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
   and `post_local` won't anymore call `poll` on a running worker automatically,
   for more information, see:
   https://github.com/Kong/lua-resty-worker-events#200-16-september-2020
+* feature: Added support for https_sni [#49](https://github.com/Kong/lua-resty-healthcheck/pull/49)
 * fix: properly log line numbers by using tail calls [#29](https://github.com/Kong/lua-resty-healthcheck/pull/29)
 * fix: when not providing a hostname, use IP [#48](https://github.com/Kong/lua-resty-healthcheck/pull/48)
 * fix: makefile; make install

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -830,11 +830,7 @@ function checker:run_single_check(ip, port, hostname, hostheader)
 
   if self.checks.active.type == "https" then
     local https_sni, session, err
-    if self.checks.active.https_sni then
-      https_sni = self.checks.active.https_sni
-    else
-      https_sni = hostheader or hostname
-    end
+    https_sni = self.checks.active.https_sni or hostheader or hostname
     if self.ssl_cert and self.ssl_key then
       session, err = sock:tlshandshake({
         verify = self.checks.active.https_verify_certificate,
@@ -1290,12 +1286,13 @@ end
 --
 -- * `name`: name of the health checker
 -- * `shm_name`: the name of the `lua_shared_dict` specified in the Nginx configuration to use
--- * `checks.active.type`: "http", "https" or "tcp" (default is "http")
 -- * `ssl_cert`: certificate for mTLS connections (string or parsed object)
 -- * `ssl_key`: key for mTLS connections (string or parsed object)
+-- * `checks.active.type`: "http", "https" or "tcp" (default is "http")
 -- * `checks.active.timeout`: socket timeout for active checks (in seconds)
 -- * `checks.active.concurrency`: number of targets to check concurrently
 -- * `checks.active.http_path`: path to use in `GET` HTTP request to run on active checks
+-- * `checks.active.https_sni`: SNI server name incase of HTTPS
 -- * `checks.active.https_verify_certificate`: boolean indicating whether to verify the HTTPS certificate
 -- * `checks.active.healthy.interval`: interval between checks for healthy targets (in seconds)
 -- * `checks.active.healthy.http_statuses`: which HTTP statuses to consider a success


### PR DESCRIPTION
The https_sni setting used for Kong Upstream health checks isn't honored by the lua-resty-healthcheck library. This makes it difficult to use health checks against backend services which only accepts SNI . 

This PR contains the patch we have currently applied to our own Kong docker images in order to solve this issue. I'm not a lua programmer so I will be surprised if this PR is accepted without changes. Especially the change involving sock:tlshandshake should be validated and potentially changed as I haven't even tested if it works.

Ref https://github.com/Kong/kong/issues/6333. 