### PR TITLE
fix(tcp failure) disabling tcp check on http(s) checks is not allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
   and `post_local` won't anymore call `poll` on a running worker automatically,
   for more information, see:
   https://github.com/Kong/lua-resty-worker-events#200-16-september-2020
+* BREAKING: tcp_failures can no longer be 0 on http(s) checks (unless http(s)_failures
+  are also set to 0) [#55](https://github.com/Kong/lua-resty-healthcheck/pull/55)
 * feature: Added support for https_sni [#49](https://github.com/Kong/lua-resty-healthcheck/pull/49)
 * fix: properly log line numbers by using tail calls [#29](https://github.com/Kong/lua-resty-healthcheck/pull/29)
 * fix: when not providing a hostname, use IP [#48](https://github.com/Kong/lua-resty-healthcheck/pull/48)

--- a/t/07-report_tcp_failure.t
+++ b/t/07-report_tcp_failure.t
@@ -130,7 +130,7 @@ qq{
                         unhealthy  = {
                             interval = 999, -- we don't want active checks
                             tcp_failures = 0,
-                            http_failures = 5,
+                            http_failures = 0,
                         }
                     },
                     passive = {
@@ -208,7 +208,7 @@ qq{
                         },
                         unhealthy  = {
                             tcp_failures = 0,
-                            http_failures = 5,
+                            http_failures = 0,
                         }
                     }
                 }


### PR DESCRIPTION
This will not also increment http failures upon a tcp failure, but only make sure the TCP threshold cannot be 0. It is not the ideal solution, but will suffice in at least making sure it trips.
(the ideal solution is rather complex as multiple counters need to be updated, but currently each update is locking and unlocking etc.)
fixes #30 
