### PR TITLE
fix(healthcheck) ensure `last_run` is updated when there's "nothing to do"

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1027,6 +1027,7 @@ local function checker_callback(self, health_mode)
 
   if not list_to_check[1] then
     self:log(DEBUG, "checking ", health_mode, " targets: nothing to do")
+    self.checks.active[health_mode].last_run = ngx_now()
   else
     local timer, err = resty_timer({
       interval = 0,


### PR DESCRIPTION
When investigating some unexpected healthcheck behaviour in Kong `2.4.1` I noticed that the healthchecks seemed to go into an "infinite" loop when there was nothing to do for a specific status (healthy/unhealthy). This seems to be because `last_run` is not being set when there is nothing to be done, resulting in the `active_check_timer` (which runs every `0.1` seconds) rescheduling the check almost immediately. 

https://github.com/Kong/lua-resty-healthcheck/blob/0d816f5b8c1a3f209e12c5677dcc0fff29181039/lib/resty/healthcheck.lua#L1439-L1451

This not only spams the logs but also results in unnecessary CPU usage (albeit minor). 

I see `v2.0.0` has been "released" and this takes a different approach to the scheduling of checks so have opened this against the `release/1.4.1` branch. 

Log of issue:
```
kong_1            | Waiting for PostgreSQL on 'kong-database:5432'.  up!
kong_1            | Database already bootstrapped
kong_1            | Database is already up-to-date
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] globalpatches.lua:10: installing the globalpatches
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:455: init(): [dns-client] (re)configuring dns client
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:460: init(): [dns-client] staleTtl = 4
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:463: init(): [dns-client] validTtl = nil
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:467: init(): [dns-client] noSynchronisation = false
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:486: init(): [dns-client] query order = LAST, SRV, A, CNAME
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: vagranthost = 10.0.2.2
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: 403b6cb5981f = 172.26.128.5
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:585: init(): [dns-client] nameserver 127.0.0.11
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:590: init(): [dns-client] attempts = 5
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:597: init(): [dns-client] no_random = true
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:606: init(): [dns-client] timeout = 2000 ms
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:610: init(): [dns-client] ndots = 1
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:612: init(): [dns-client] search = 
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:618: init(): [dns-client] badTtl = 1 s
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] client.lua:620: init(): [dns-client] emptyTtl = 30 s
kong_1            | 2021/05/31 12:55:22 [debug] 1#0: [lua] globalpatches.lua:263: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:455: init(): [dns-client] (re)configuring dns client
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:460: init(): [dns-client] staleTtl = 4
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:463: init(): [dns-client] validTtl = nil
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:467: init(): [dns-client] noSynchronisation = false
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:486: init(): [dns-client] query order = LAST, SRV, A, CNAME
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: vagranthost = 10.0.2.2
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: 403b6cb5981f = 172.26.128.5
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:585: init(): [dns-client] nameserver 127.0.0.11
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:590: init(): [dns-client] attempts = 5
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:597: init(): [dns-client] no_random = true
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:606: init(): [dns-client] timeout = 2000 ms
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:610: init(): [dns-client] ndots = 1
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:612: init(): [dns-client] search = 
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:618: init(): [dns-client] badTtl = 1 s
kong_1            | 2021/05/31 12:55:23 [debug] 1#0: [lua] client.lua:620: init(): [dns-client] emptyTtl = 30 s
kong_1            | 2021/05/31 12:55:24 [debug] 1#0: [lua] plugins.lua:245: load_plugin(): Loading plugin: request-transformer
kong_1            | 2021/05/31 12:55:24 [notice] 1#0: using the "epoll" event method
kong_1            | 2021/05/31 12:55:24 [notice] 1#0: openresty/1.19.3.1
kong_1            | 2021/05/31 12:55:24 [notice] 1#0: built by gcc 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04) 
kong_1            | 2021/05/31 12:55:24 [notice] 1#0: OS: Linux 4.15.0-143-generic
kong_1            | 2021/05/31 12:55:24 [notice] 1#0: getrlimit(RLIMIT_NOFILE): 1048576:1048576
kong_1            | 2021/05/31 12:55:24 [notice] 1#0: start worker processes
kong_1            | 2021/05/31 12:55:24 [notice] 1#0: start worker process 50
kong_1            | 2021/05/31 12:55:24 [debug] 50#0: *1 [lua] globalpatches.lua:263: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
kong_1            | 2021/05/31 12:55:24 [debug] 50#0: *1 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=50, data=nil
kong_1            | 2021/05/31 12:55:24 [notice] 50#0: *1 [lua] warmup.lua:92: single_dao(): Preloading 'services' into the core_cache..., context: init_worker_by_lua*
kong_1            | 2021/05/31 12:55:25 [notice] 50#0: *1 [lua] warmup.lua:129: single_dao(): finished preloading 'services' into the core_cache (in 451ms), context: init_worker_by_lua*
kong_1            | 2021/05/31 12:55:25 [notice] 50#0: *2 [lua] warmup.lua:34: warming up DNS entries ..., context: ngx.timer
kong_1            | 2021/05/31 12:55:25 [debug] 50#0: *3 [lua] base.lua:1503: new(): [upstream:mock 1] balancer_base created
kong_1            | 2021/05/31 12:55:25 [debug] 50#0: *3 [lua] round_robin.lua:165: new(): [upstream:mock 1] round_robin balancer created
kong_1            | 2021/05/31 12:55:25 [debug] 50#0: *3 [lua] base.lua:917: newHost(): [upstream:mock 1] created a new host for: mock
kong_1            | 2021/05/31 12:55:25 [debug] 50#0: *3 [lua] base.lua:655: queryDns(): [upstream:mock 1] querying dns for mock
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] base.lua:570: f(): [upstream:mock 1] dns record type changed for mock, nil -> 1
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] base.lua:370: newAddress(): [upstream:mock 1] new address for host 'mock' created: 172.26.128.4:3000 (weight 10)
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] base.lua:634: f(): [upstream:mock 1] updating balancer based on dns changes for mock
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] base.lua:644: f(): [upstream:mock 1] querying dns and updating for mock completed
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Got initial target list (0 targets)
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) active check flagged as active
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Healthchecker started!
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=lua-resty-healthcheck [bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock], event=healthy, pid=50, data=table: 0x7f5ff03d9098
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target added 'mock(172.26.128.4:3000)'
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target status 'mock(172.26.128.4:3000)' from 'false' to 'true'
kong_1            | 2021/05/31 12:55:26 [debug] 50#0: *3 [lua] balancer.lua:844: create_balancers(): initialized 1 balancer(s), 0 error(s)
kong_1            | 2021/05/31 12:55:26 [notice] 50#0: *2 [lua] warmup.lua:58: finished warming up DNS entries' into the cache (in 1255ms), context: ngx.timer
kong_1            | 2021/05/31 12:55:29 [debug] 50#0: *39 [lua] init.lua:288: [cluster_events] polling events from: 1622465724.816
kong_1            | 2021/05/31 12:55:34 [debug] 50#0: *47 [lua] init.lua:288: [cluster_events] polling events from: 1622465724.816
kong_1            | 2021/05/31 12:55:39 [debug] 50#0: *55 [lua] init.lua:288: [cluster_events] polling events from: 1622465724.816
kong_1            | 2021/05/31 12:55:44 [debug] 50#0: *63 [lua] init.lua:288: [cluster_events] polling events from: 1622465724.816
kong_1            | 2021/05/31 12:55:49 [debug] 50#0: *71 [lua] init.lua:288: [cluster_events] polling events from: 1622465724.816
kong_1            | 2021/05/31 12:55:54 [debug] 50#0: *79 [lua] init.lua:288: [cluster_events] polling events from: 1622465724.816
kong_1            | 2021/05/31 12:55:59 [debug] 50#0: *87 [lua] init.lua:288: [cluster_events] polling events from: 1622465724.816
kong_1            | 2021/05/31 12:56:02 [debug] 50#0: *93 [lua] init.lua:27: Loading Admin API endpoints
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] init.lua:118: No API endpoints loaded for plugin: request-transformer
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event(): worker-events: handling event; source=dao:crud, event=update, pid=nil, data=table: 0x7f5feb9345b8
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] init.lua:229: invalidate_local(): [DB cache] invalidating (local): 'upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca:::::bdd6a8cd-50a2-4650-aba2-2e2cf172dc85'
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:invalidations:kong_core_db_cache, pid=50, data=upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca:::::bdd6a8cd-50a2-4650-aba2-2e2cf172dc85
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] init.lua:250: invalidate(): [DB cache] broadcasting (cluster) invalidation for key: 'upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca:::::bdd6a8cd-50a2-4650-aba2-2e2cf172dc85'
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event(): worker-events: handling event; source=crud, event=upstreams, pid=nil, data=table: 0x7f5feb9345b8
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=balancer, event=upstreams, pid=50, data=table: 0x7f5feb937868
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] init.lua:229: invalidate_local(): [DB cache] invalidating (local): 'balancer:upstreams'
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] init.lua:229: invalidate_local(): [DB cache] invalidating (local): 'balancer:upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca'
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] init.lua:229: invalidate_local(): [DB cache] invalidating (local): 'balancer:targets:26c5e536-8e5f-4f5d-a291-702883dedbca'
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) healthchecker stopped
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] base.lua:1503: new(): [upstream:mock 2] balancer_base created
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] round_robin.lua:165: new(): [upstream:mock 2] round_robin balancer created
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] base.lua:917: newHost(): [upstream:mock 2] created a new host for: mock
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] base.lua:655: queryDns(): [upstream:mock 2] querying dns for mock
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] base.lua:570: f(): [upstream:mock 2] dns record type changed for mock, nil -> 1
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] base.lua:370: newAddress(): [upstream:mock 2] new address for host 'mock' created: 172.26.128.4:3000 (weight 10)
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] base.lua:634: f(): [upstream:mock 2] updating balancer based on dns changes for mock
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] base.lua:644: f(): [upstream:mock 2] querying dns and updating for mock completed
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Got initial target list (0 targets)
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) active check flagged as active
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) starting timer to check active checks
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Healthchecker started!
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:invalidations:kong_core_db_cache, pid=50, data=balancer:upstreams
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:invalidations:kong_core_db_cache, pid=50, data=balancer:upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:invalidations:kong_core_db_cache, pid=50, data=balancer:targets:26c5e536-8e5f-4f5d-a291-702883dedbca
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=lua-resty-healthcheck [bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock], event=clear, pid=50, data=table: 0x7f5feb94b5e0
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: local cache cleared
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: local cache cleared
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=lua-resty-healthcheck [bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock], event=healthy, pid=50, data=table: 0x7f5feb94bc30
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target added 'mock(172.26.128.4:3000)'
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target status 'mock(172.26.128.4:3000)' from 'false' to 'true'
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target added 'mock(172.26.128.4:3000)'
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target status 'mock(172.26.128.4:3000)' from 'false' to 'true'
kong_1            | 2021/05/31 12:56:03 [debug] 50#0: *93 [lua] events.lua:211: do_event(): worker-events: handling event; source=crud, event=upstreams:update, pid=nil, data=table: 0x7f5feb9345b8
kong_1            | 172.26.128.6 - - [31/May/2021:12:56:03 +0000] "PATCH /upstreams/26c5e536-8e5f-4f5d-a291-702883dedbca HTTP/1.1" 200 951 "-" "-"
kong_1            | 2021/05/31 12:56:04 [debug] 50#0: *98 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) worker 0 (pid: 50) starting active check timer
kong_1            | 2021/05/31 12:56:04 [debug] 50#0: *100 [lua] init.lua:288: [cluster_events] polling events from: 1622465724.816
kong_1            | 2021/05/31 12:56:09 [debug] 50#0: *108 [lua] init.lua:288: [cluster_events] polling events from: 1622465764.706
kong_1            | 2021/05/31 12:56:13 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:13 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:13 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:13 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:13 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:13 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:13 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *116 [lua] init.lua:288: [cluster_events] polling events from: 1622465764.706
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:14 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:15 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:16 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:17 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:18 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:18 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:18 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:18 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:18 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:18 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:18 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:18 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:18 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *124 [lua] init.lua:288: [cluster_events] polling events from: 1622465764.706
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:19 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:20 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:21 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:21 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:21 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:21 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:21 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:21 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:21 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:21 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:21 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:22 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:23 [debug] 50#0: *99 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event(): worker-events: handling event; source=dao:crud, event=update, pid=nil, data=table: 0x7f5feb90d318
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] init.lua:229: invalidate_local(): [DB cache] invalidating (local): 'upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca:::::bdd6a8cd-50a2-4650-aba2-2e2cf172dc85'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:invalidations:kong_core_db_cache, pid=50, data=upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca:::::bdd6a8cd-50a2-4650-aba2-2e2cf172dc85
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] init.lua:250: invalidate(): [DB cache] broadcasting (cluster) invalidation for key: 'upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca:::::bdd6a8cd-50a2-4650-aba2-2e2cf172dc85'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event(): worker-events: handling event; source=crud, event=upstreams, pid=nil, data=table: 0x7f5feb90d318
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=balancer, event=upstreams, pid=50, data=table: 0x7f5feb90f4a8
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] init.lua:229: invalidate_local(): [DB cache] invalidating (local): 'balancer:upstreams'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] init.lua:229: invalidate_local(): [DB cache] invalidating (local): 'balancer:upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] init.lua:229: invalidate_local(): [DB cache] invalidating (local): 'balancer:targets:26c5e536-8e5f-4f5d-a291-702883dedbca'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) healthchecker stopped
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] base.lua:1503: new(): [upstream:mock 3] balancer_base created
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] round_robin.lua:165: new(): [upstream:mock 3] round_robin balancer created
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] base.lua:917: newHost(): [upstream:mock 3] created a new host for: mock
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] base.lua:655: queryDns(): [upstream:mock 3] querying dns for mock
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] base.lua:570: f(): [upstream:mock 3] dns record type changed for mock, nil -> 1
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] base.lua:370: newAddress(): [upstream:mock 3] new address for host 'mock' created: 172.26.128.4:3000 (weight 10)
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] base.lua:634: f(): [upstream:mock 3] updating balancer based on dns changes for mock
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] base.lua:644: f(): [upstream:mock 3] querying dns and updating for mock completed
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Got initial target list (0 targets)
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) active check flagged as active
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Healthchecker started!
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:invalidations:kong_core_db_cache, pid=50, data=balancer:upstreams
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:invalidations:kong_core_db_cache, pid=50, data=balancer:upstreams:26c5e536-8e5f-4f5d-a291-702883dedbca
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:invalidations:kong_core_db_cache, pid=50, data=balancer:targets:26c5e536-8e5f-4f5d-a291-702883dedbca
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=lua-resty-healthcheck [bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock], event=clear, pid=50, data=table: 0x7f5feb8e3140
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: local cache cleared
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: local cache cleared
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: local cache cleared
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=lua-resty-healthcheck [bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock], event=healthy, pid=50, data=table: 0x7f5feb8e3588
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target added 'mock(172.26.128.4:3000)'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target status 'mock(172.26.128.4:3000)' from 'false' to 'true'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target added 'mock(172.26.128.4:3000)'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target status 'mock(172.26.128.4:3000)' from 'false' to 'true'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target added 'mock(172.26.128.4:3000)'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] healthcheck.lua:1123: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target status 'mock(172.26.128.4:3000)' from 'false' to 'true'
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *131 [lua] events.lua:211: do_event(): worker-events: handling event; source=crud, event=upstreams:update, pid=nil, data=table: 0x7f5feb90d318
kong_1            | 172.26.128.6 - - [31/May/2021:12:56:24 +0000] "PATCH /upstreams/26c5e536-8e5f-4f5d-a291-702883dedbca HTTP/1.1" 200 950 "-" "-"
kong_1            | 2021/05/31 12:56:24 [debug] 50#0: *136 [lua] init.lua:288: [cluster_events] polling events from: 1622465764.706
```
