### PR TITLE
fix(healthcheck) record `last_run` when healthcheck is scheduled rather than completed

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1036,7 +1036,6 @@ local function checker_callback(self, health_mode)
       expire = function()
         self:log(DEBUG, "checking ", health_mode, " targets: #", #list_to_check)
         self:active_check_targets(list_to_check)
-        self.checks.active[health_mode].last_run = ngx_now()
       end,
     })
     if timer == nil then
@@ -1479,6 +1478,7 @@ function _M.new(opts)
                   (checker_obj.checks.active.healthy.last_run +
                   checker_obj.checks.active.healthy.interval <= cur_time)
                 then
+                  checker_obj.checks.active.healthy.last_run = cur_time
                   checker_callback(checker_obj, "healthy")
                 end
 
@@ -1486,6 +1486,7 @@ function _M.new(opts)
                   (checker_obj.checks.active.unhealthy.last_run +
                   checker_obj.checks.active.unhealthy.interval <= cur_time)
                 then
+                  checker_obj.checks.active.unhealthy.last_run = cur_time
                   checker_callback(checker_obj, "unhealthy")
                 end
               end


### PR DESCRIPTION
The `active_check_timer` in this library is currently executed every `0.1` seconds. 

https://github.com/Kong/lua-resty-healthcheck/blob/9e9a9360129cdd3e4472ca23d94b23ceb5fdefe1/lib/resty/healthcheck.lua#L1470-L1493

This loop checks the value of `last_run` to determine whether or not to schedule a healthcheck. However, `last_run` is only set once the check completes:

https://github.com/Kong/lua-resty-healthcheck/blob/9e9a9360129cdd3e4472ca23d94b23ceb5fdefe1/lib/resty/healthcheck.lua#L1031-L1041

In the case that the healthcheck for a set of targets takes longer than `0.1` seconds to complete, this results in additional healthchecks being scheduled rather than waiting for the configured `interval` to pass. This can cause multiple issues and even lead to a thundering herd style problem on upstreams that are _having issues_. To begin with, if `unhealthy failures` are set to a number less than the total number of checks that are scheduled in the period it takes to complete a healthcheck then a target will be marked as `UNHEALTHY` immediately. E.g. I have a timeout of 1 second set, if an upstream broaches that time because of some network glitch then I could potentially have `10` healthcheck scheduled in the period in which it take the first to complete. If my `Unhealthy timeouts/failures` happens to be 5 then my target could quite easily be marked as `UNHEALTHY` after what should have been a single healthcheck. The problem is subsequently compounded when running a cluster of Kong nodes, particularly if one checks unhealthy targets more often that healthy (because one wants to mark the upstream/target as healthy quickly as possible). In my case this prevented an upstream from coming back up again. 

Supersedes #70 (resolves that issue in addition to the one described above). 

Resolves https://github.com/Kong/kong/issues/7409

Logs:
```
kong_1            | Waiting for PostgreSQL on 'kong-database:5432'.  up!
kong_1            | Database already bootstrapped
kong_1            | Database is already up-to-date
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] globalpatches.lua:10: installing the globalpatches
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:455: init(): [dns-client] (re)configuring dns client
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:460: init(): [dns-client] staleTtl = 4
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:463: init(): [dns-client] validTtl = nil
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:467: init(): [dns-client] noSynchronisation = false
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:486: init(): [dns-client] query order = LAST, SRV, A, CNAME
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: vagranthost = 10.0.2.2
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: b3445413d294 = 172.26.128.5
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:585: init(): [dns-client] nameserver 127.0.0.11
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:590: init(): [dns-client] attempts = 5
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:597: init(): [dns-client] no_random = true
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:606: init(): [dns-client] timeout = 2000 ms
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:610: init(): [dns-client] ndots = 1
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:612: init(): [dns-client] search =
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:618: init(): [dns-client] badTtl = 1 s
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:620: init(): [dns-client] emptyTtl = 30 s
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] globalpatches.lua:263: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:455: init(): [dns-client] (re)configuring dns client
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:460: init(): [dns-client] staleTtl = 4
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:463: init(): [dns-client] validTtl = nil
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:467: init(): [dns-client] noSynchronisation = false
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:486: init(): [dns-client] query order = LAST, SRV, A, CNAME
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: vagranthost = 10.0.2.2
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:541: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:526: init(): [dns-client] adding A-record from 'hosts' file: b3445413d294 = 172.26.128.5
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:585: init(): [dns-client] nameserver 127.0.0.11
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:590: init(): [dns-client] attempts = 5
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:597: init(): [dns-client] no_random = true
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:606: init(): [dns-client] timeout = 2000 ms
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:610: init(): [dns-client] ndots = 1
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:612: init(): [dns-client] search =
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:618: init(): [dns-client] badTtl = 1 s
kong_1            | 2021/06/01 07:39:21 [debug] 1#0: [lua] client.lua:620: init(): [dns-client] emptyTtl = 30 s
kong_1            | 2021/06/01 07:39:22 [debug] 1#0: [lua] plugins.lua:245: load_plugin(): Loading plugin: request-transformer
kong_1            | 2021/06/01 07:39:22 [notice] 1#0: using the "epoll" event method
kong_1            | 2021/06/01 07:39:22 [notice] 1#0: openresty/1.19.3.1
kong_1            | 2021/06/01 07:39:22 [notice] 1#0: built by gcc 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)
kong_1            | 2021/06/01 07:39:22 [notice] 1#0: OS: Linux 4.15.0-143-generic
kong_1            | 2021/06/01 07:39:22 [notice] 1#0: getrlimit(RLIMIT_NOFILE): 1048576:1048576
kong_1            | 2021/06/01 07:39:22 [notice] 1#0: start worker processes
kong_1            | 2021/06/01 07:39:22 [notice] 1#0: start worker process 43
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *1 [lua] globalpatches.lua:263: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *1 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=43, data=nil
kong_1            | 2021/06/01 07:39:22 [notice] 43#0: *1 [lua] warmup.lua:92: single_dao(): Preloading 'services' into the core_cache..., context: init_worker_by_lua*
kong_1            | 2021/06/01 07:39:22 [notice] 43#0: *1 [lua] warmup.lua:129: single_dao(): finished preloading 'services' into the core_cache (in 76ms), context: init_worker_by_lua*
kong_1            | 2021/06/01 07:39:22 [notice] 43#0: *2 [lua] warmup.lua:34: warming up DNS entries ..., context: ngx.timer
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] base.lua:1503: new(): [upstream:mock 1] balancer_base created
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] round_robin.lua:165: new(): [upstream:mock 1] round_robin balancer created
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] base.lua:917: newHost(): [upstream:mock 1] created a new host for: mock.example.com
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] base.lua:655: queryDns(): [upstream:mock 1] querying dns for mock.example.com
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] base.lua:570: f(): [upstream:mock 1] dns record type changed for mock.example.com, nil -> 1
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] base.lua:370: newAddress(): [upstream:mock 1] new address for host 'mock.example.com' created: 0.0.0.0:443 (weight 10)
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] base.lua:634: f(): [upstream:mock 1] updating balancer based on dns changes for mock.example.com
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] base.lua:644: f(): [upstream:mock 1] querying dns and updating for mock.example.com completed
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Got initial target list (0 targets)
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) active check flagged as active
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) starting timer to check active checks
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Healthchecker started!
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=lua-resty-healthcheck [bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock], event=healthy, pid=43, data=table: 0x7fdc2035e248
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target added 'mock.example.com(0.0.0.0:443)'
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) event: target status 'mock.example.com(0.0.0.0:443)' from 'false' to 'true'
kong_1            | 2021/06/01 07:39:22 [debug] 43#0: *3 [lua] balancer.lua:850: create_balancers(): initialized 1 balancer(s), 0 error(s)
kong_1            | 2021/06/01 07:39:22 [notice] 43#0: *2 [lua] warmup.lua:58: finished warming up DNS entries' into the cache (in 750ms), context: ngx.timer
kong_1            | 2021/06/01 07:39:23 [debug] 43#0: *40 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) worker 0 (pid: 43) starting active check timer
kong_1            | 2021/06/01 07:39:27 [debug] 43#0: *45 [lua] init.lua:288: [cluster_events] polling events from: 1622533162.126
kong_1            | 2021/06/01 07:39:32 [debug] 43#0: *53 [lua] init.lua:288: [cluster_events] polling events from: 1622533162.126
kong_1            | 2021/06/01 07:39:37 [debug] 43#0: *61 [lua] init.lua:288: [cluster_events] polling events from: 1622533162.126
kong_1            | 2021/06/01 07:39:37 [debug] 43#0: *41 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/06/01 07:39:42 [debug] 43#0: *69 [lua] init.lua:288: [cluster_events] polling events from: 1622533162.126
kong_1            | 2021/06/01 07:39:47 [debug] 43#0: *77 [lua] init.lua:288: [cluster_events] polling events from: 1622533162.126
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *85 [lua] init.lua:288: [cluster_events] polling events from: 1622533162.126
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *41 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking unhealthy targets: nothing to do
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *89 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking healthy targets: #1
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *89 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Checking mock.example.com 0.0.0.0:443 (currently healthy)
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *91 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking healthy targets: #1
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *91 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Checking mock.example.com 0.0.0.0:443 (currently healthy)
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *93 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking healthy targets: #1
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *93 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Checking mock.example.com 0.0.0.0:443 (currently healthy)
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *95 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking healthy targets: #1
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *95 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Checking mock.example.com 0.0.0.0:443 (currently healthy)
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *97 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) checking healthy targets: #1
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *97 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Checking mock.example.com 0.0.0.0:443 (currently healthy)
kong_1            | 2021/06/01 07:39:52 [debug] 43#0: *89 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Reporting 'mock.example.com (0.0.0.0:443)' (got HTTP 200)
kong_1            | 2021/06/01 07:39:53 [debug] 43#0: *91 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Reporting 'mock.example.com (0.0.0.0:443)' (got HTTP 200)
kong_1            | 2021/06/01 07:39:53 [debug] 43#0: *93 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Reporting 'mock.example.com (0.0.0.0:443)' (got HTTP 200)
kong_1            | 2021/06/01 07:39:53 [debug] 43#0: *95 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Reporting 'mock.example.com (0.0.0.0:443)' (got HTTP 200)
kong_1            | 2021/06/01 07:39:53 [debug] 43#0: *97 [lua] healthcheck.lua:1127: log(): [healthcheck] (bdd6a8cd-50a2-4650-aba2-2e2cf172dc85:mock) Reporting 'mock.example.com (0.0.0.0:443)' (got HTTP 200)
kong_1            | 2021/06/01 07:39:57 [debug] 43#0: *103 [lua] init.lua:288: [cluster_events] polling events from: 1622533162.126
```