### PR TITLE
tests(active-probes) interval is respected

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1005,6 +1005,10 @@ end
 -- @param self the checker object this timer runs on
 -- @param health_mode either "healthy" or "unhealthy" to indicate what check
 local function checker_callback(self, health_mode)
+  if self.checker_callback_count then
+    self.checker_callback_count = self.checker_callback_count + 1
+  end
+
   local list_to_check = {}
   local targets = fetch_target_list(self)
   for _, target in ipairs(targets) do
@@ -1348,6 +1352,7 @@ function _M.new(opts)
 
   if opts.test then
     self.test_get_counter = test_get_counter
+    self.checker_callback_count = 0
   end
 
   assert(self.name, "required option 'name' is missing")

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1036,7 +1036,6 @@ local function checker_callback(self, health_mode)
       expire = function()
         self:log(DEBUG, "checking ", health_mode, " targets: #", #list_to_check)
         self:active_check_targets(list_to_check)
-        self.checks.active[health_mode].last_run = ngx_now()
       end,
     })
     if timer == nil then
@@ -1479,6 +1478,7 @@ function _M.new(opts)
                   (checker_obj.checks.active.healthy.last_run +
                   checker_obj.checks.active.healthy.interval <= cur_time)
                 then
+                  checker_obj.checks.active.healthy.last_run = cur_time
                   checker_callback(checker_obj, "healthy")
                 end
 
@@ -1486,6 +1486,7 @@ function _M.new(opts)
                   (checker_obj.checks.active.unhealthy.last_run +
                   checker_obj.checks.active.unhealthy.interval <= cur_time)
                 then
+                  checker_obj.checks.active.unhealthy.last_run = cur_time
                   checker_callback(checker_obj, "unhealthy")
                 end
               end


### PR DESCRIPTION
Add tests for https://github.com/Kong/lua-resty-healthcheck/pull/72

If you run these tests against the branch `release/1.4.1` it will fail, i.e., `BAD` will be returned in the `response_body`.