### PR TITLE
fix(healthcheck): fixed incorrect default http_statuses when new() was called multiple times

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1257,52 +1257,52 @@ local function fill_in_settings(opts, defaults, ctx)
   return obj
 end
 
-
-local defaults = {
-  name = NO_DEFAULT,
-  shm_name = NO_DEFAULT,
-  type = NO_DEFAULT,
-  status_ver = 0,
-  checks = {
-    active = {
-      type = "http",
-      timeout = 1,
-      concurrency = 10,
-      http_path = "/",
-      https_sni = NO_DEFAULT,
-      https_verify_certificate = true,
-      headers = {""},
-      healthy = {
-        interval = 0, -- 0 = disabled by default
-        http_statuses = { 200, 302 },
-        successes = 2,
+local function get_defaults()
+  return {
+    name = NO_DEFAULT,
+    shm_name = NO_DEFAULT,
+    type = NO_DEFAULT,
+    status_ver = 0,
+    checks = {
+      active = {
+        type = "http",
+        timeout = 1,
+        concurrency = 10,
+        http_path = "/",
+        https_sni = NO_DEFAULT,
+        https_verify_certificate = true,
+        headers = {""},
+        healthy = {
+          interval = 0, -- 0 = disabled by default
+          http_statuses = { 200, 302 },
+          successes = 2,
+        },
+        unhealthy = {
+          interval = 0, -- 0 = disabled by default
+          http_statuses = { 429, 404,
+                            500, 501, 502, 503, 504, 505 },
+          tcp_failures = 2,
+          timeouts = 3,
+          http_failures = 5,
+        },
       },
-      unhealthy = {
-        interval = 0, -- 0 = disabled by default
-        http_statuses = { 429, 404,
-                          500, 501, 502, 503, 504, 505 },
-        tcp_failures = 2,
-        timeouts = 3,
-        http_failures = 5,
+      passive = {
+        type = "http",
+        healthy = {
+          http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+                            300, 301, 302, 303, 304, 305, 306, 307, 308 },
+          successes = 5,
+        },
+        unhealthy = {
+          http_statuses = { 429, 500, 503 },
+          tcp_failures = 2,
+          timeouts = 7,
+          http_failures = 5,
+        },
       },
     },
-    passive = {
-      type = "http",
-      healthy = {
-        http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
-                          300, 301, 302, 303, 304, 305, 306, 307, 308 },
-        successes = 5,
-      },
-      unhealthy = {
-        http_statuses = { 429, 500, 503 },
-        tcp_failures = 2,
-        timeouts = 7,
-        http_failures = 5,
-      },
-    },
-  },
-}
-
+  }
+end
 
 local function to_set(tbl, key)
   local set = {}
@@ -1374,6 +1374,8 @@ function _M.new(opts)
   assert(worker_events.configured(), "please configure the " ..
       "'lua-resty-worker-events' module before using 'lua-resty-healthcheck'")
 
+  -- create a new defaults table within new() as defaults table will be modified by to_set function later 
+  local defaults = get_defaults()
   local self = fill_in_settings(opts, defaults)
 
   assert(self.checks.active.healthy.successes < 255,        "checks.active.healthy.successes must be at most 254")

--- a/t/00-new.t
+++ b/t/00-new.t
@@ -3,7 +3,7 @@ use Cwd qw(cwd);
 
 workers(1);
 
-plan tests => repeat_each() * (blocks() * 3) - 2;
+plan tests => repeat_each() * (blocks() * 3) - 3;
 
 my $pwd = cwd();
 
@@ -251,3 +251,63 @@ false
 false
 false
 false
+
+=== TEST 8: new() was called multiple times with input which do not have healthy/unhealthy config
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+
+            -- CASE 1: default http_statuses should be set correctly when new() was called multiple times
+            local hc1 = healthcheck.new({
+              name = "testing",
+              shm_name = "test_shm",
+              checks = {
+                  active = {
+                      type = "http",
+                  },
+              }
+            })
+            -- make sure checks.active.healthy.http_statuses is filled with defaults
+            ngx.say(hc1.checks.active.healthy.http_statuses[200])
+
+            local hc2 = healthcheck.new({
+              name = "testing",
+              shm_name = "test_shm",
+              checks = {
+                  active = {
+                      type = "http",
+                  },
+              }
+            })
+            -- make sure checks.active.healthy.http_statuses is filled with defaults
+            ngx.say(hc2.checks.active.healthy.http_statuses[200])
+
+            -- CASE 2: the given http_statuses should not be overridden by default
+            local hc3 = healthcheck.new({
+              name = "testing",
+              shm_name = "test_shm",
+              checks = {
+                  active = {
+                      type = "http",
+                      healthy = {
+                          http_statuses = {201}
+                      }
+                  },
+              }
+            })
+            -- make sure defaults won't override the given input
+            ngx.say(hc3.checks.active.healthy.http_statuses[200])
+            ngx.say(hc3.checks.active.healthy.http_statuses[201])
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+true
+nil
+true


### PR DESCRIPTION
In `new()` function,  `self.checks` is filled with `defaults` if any parameter is not given, for example if `checks.active.healthy` is not given, it will be set to the default value which is defined in the local `defaults` variable:

```
healthy = {
  interval = 0,
  http_statuses = { 200, 302 },
  successes = 2,
}
```

However `new()` also modifies `http_statuses` value in `self.checks` from array (`{200, 201}`) to map (`{"200":true, "201":true}`) by `to_set` function, which also modifies the local `defaults` table, and will make default `http_statuses` incorrect if `new()` is called after `defaults` is modified, and affect the health check.

This PR fixed the issue by creating a local `defaults` within the `new()` function scope, so the behavior of a `new()` usage won't modifies other `new()` result.