### PR TITLE
fix(mtls) update to use newer mTLS api

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -899,17 +899,16 @@ function checker:run_single_check(ip, port, hostname, hostheader)
   if self.checks.active.type == "https" then
     local https_sni, session, err
     https_sni = self.checks.active.https_sni or hostheader or hostname
+
     if self.ssl_cert and self.ssl_key then
-      session, err = sock:tlshandshake({
-        verify = self.checks.active.https_verify_certificate,
-        client_cert = self.ssl_cert,
-        client_priv_key = self.ssl_key,
-        server_name = https_sni
-      })
-    else
-      session, err = sock:sslhandshake(nil, https_sni,
-                                     self.checks.active.https_verify_certificate)
+      ok, err = sock:setclientcert(self.ssl_cert, self.ssl_key)
+      if not ok then
+        self:log(ERR, "failed to set client certificate: ", err)
+      end
     end
+
+    session, err = sock:sslhandshake(nil, https_sni,
+                                     self.checks.active.https_verify_certificate)
     if not session then
       sock:close()
       self:log(ERR, "failed SSL handshake with '", hostname or "", " (", ip, ":", port, ")', using server name (sni) '", https_sni, "': ", err)


### PR DESCRIPTION
This revises the mTLS code to use the newer version of that feature (i.e. `setclientcert` instead of `tlshandshake`).

The relevant PRs are [here](https://github.com/openresty/lua-nginx-module/pull/1602) and [here](https://github.com/openresty/lua-resty-core/pull/278).

However, the tests in this repo do not touch this code path, which is a little alarming, but also perhaps understandable since the feature isn't available in OpenResty mainline.

Merging this will be harmless to anyone not using mTLS, but will break for anyone using the old patch set. The reason for this PR is to try to unravel this tech debt as we push towards proper cosocket mTLS support in OpenResty.
