### PR TITLE
fix: healthcheck to targets stopped after update upstream

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1474,7 +1474,7 @@ function _M.new(opts)
         end
 
         local cur_time = ngx_now()
-        for _, checker_obj in ipairs(hcs) do
+        for _, checker_obj in pairs(hcs) do
           if checker_obj.checks.active.healthy.active and
             (checker_obj.checks.active.healthy.last_run +
               checker_obj.checks.active.healthy.interval <= cur_time)


### PR DESCRIPTION
Same as #78, but rebased to `release/1.4.x` branch. 

Original description:

---

Hi,

As I reported in the issue https://github.com/Kong/kong/issues/7652

When I updated an upstream, healthcheck to targets of this upstream has been stopped.

The bug is by using `weak table` and `ipairs` 
So, when I updated an upstream, Kong insert a new object contain upstream information to `hcs` table
When Lua GC removed old object of the upstream => loop with `ipairs` stopped when got first `nil` => any upstream object after nil value not will be checked

```lua
-- checker objects (weak) table
local hcs = setmetatable({}, {
    __mode = "v",
})

...

for _, checker_obj in ipairs(hcs) do
```

---

Closes: #78