### PR TITLE
fix(tests) init events module

### DIFF
--- a/t/with_resty-events/01-start-stop.t
+++ b/t/with_resty-events/01-start-stop.t
@@ -12,6 +12,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -33,8 +43,6 @@ __DATA__
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -70,8 +78,6 @@ true
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -110,8 +116,6 @@ true
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -145,8 +149,6 @@ checking
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",

--- a/t/with_resty-events/02-add_target.t
+++ b/t/with_resty-events/02-add_target.t
@@ -12,6 +12,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -33,13 +43,11 @@ __DATA__
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         healthy  = {
@@ -85,13 +93,11 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         http_path = "/status",
@@ -138,13 +144,11 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         http_path = "/status",

--- a/t/with_resty-events/03-get_target_status.t
+++ b/t/with_resty-events/03-get_target_status.t
@@ -15,6 +15,8 @@ our $HttpConfig = qq{
     init_worker_by_lua_block {
         local we = require "resty.events.compat"
         assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
             listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
         }))
         assert(we.configured())

--- a/t/with_resty-events/03-get_target_status.t
+++ b/t/with_resty-events/03-get_target_status.t
@@ -83,15 +83,15 @@ qq{
                 }
             })
             local ok, err = checker:add_target("127.0.0.1", 2115, nil, true)
-            ngx.sleep(0.002) -- wait for initial timers to run once
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- true
 
             checker:report_tcp_failure("127.0.0.1", 2115)
-            ngx.sleep(0.002) -- wait for initial timers to run once
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- false
 
             checker:report_success("127.0.0.1", 2115)
-            ngx.sleep(0.002) -- wait for initial timers to run once
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- true
         }
     }

--- a/t/with_resty-events/03-get_target_status.t
+++ b/t/with_resty-events/03-get_target_status.t
@@ -82,12 +82,16 @@ qq{
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2115, nil, true)
+            ngx.sleep(0.002) -- wait for initial timers to run once
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- true
+
             checker:report_tcp_failure("127.0.0.1", 2115)
+            ngx.sleep(0.002) -- wait for initial timers to run once
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- false
+
             checker:report_success("127.0.0.1", 2115)
+            ngx.sleep(0.002) -- wait for initial timers to run once
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- true
         }
     }

--- a/t/with_resty-events/03-get_target_status_with_sleeps.t
+++ b/t/with_resty-events/03-get_target_status_with_sleeps.t
@@ -82,15 +82,14 @@ qq{
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2115, nil, true)
-            ngx.sleep(0.1)
+            ngx.sleep(0.01)
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- true
             checker:report_tcp_failure("127.0.0.1", 2115)
-            ngx.sleep(0.1)
+            ngx.sleep(0.01)
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- false
             checker:report_success("127.0.0.1", 2115)
-            ngx.sleep(0.1)
+            ngx.sleep(0.01)
             ngx.say(checker:get_target_status("127.0.0.1", 2115))  -- true
         }
     }

--- a/t/with_resty-events/04-report_success.t
+++ b/t/with_resty-events/04-report_success.t
@@ -15,6 +15,8 @@ our $HttpConfig = qq{
     init_worker_by_lua_block {
         local we = require "resty.events.compat"
         assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
             listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
         }))
         assert(we.configured())
@@ -83,15 +85,16 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2116, nil, false)
             local ok, err = checker:add_target("127.0.0.1", 2118, nil, false)
+            ngx.sleep(0.002)
             checker:report_success("127.0.0.1", 2116, nil, "active")
             checker:report_success("127.0.0.1", 2118, nil, "passive")
             checker:report_success("127.0.0.1", 2116, nil, "active")
             checker:report_success("127.0.0.1", 2118, nil, "passive")
             checker:report_success("127.0.0.1", 2116, nil, "active")
             checker:report_success("127.0.0.1", 2118, nil, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- true
         }
@@ -157,15 +160,16 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2116, nil, false)
             local ok, err = checker:add_target("127.0.0.1", 2118, nil, false)
+            ngx.sleep(0.002)
             checker:report_success("127.0.0.1", 2116, nil, "active")
             checker:report_success("127.0.0.1", 2118, nil, "passive")
             checker:report_success("127.0.0.1", 2116, nil, "active")
             checker:report_success("127.0.0.1", 2118, nil, "passive")
             checker:report_success("127.0.0.1", 2116, nil, "active")
             checker:report_success("127.0.0.1", 2118, nil, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2118))  -- true
         }
@@ -230,11 +234,12 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2116, nil, false)
+            ngx.sleep(0.002)
             checker:report_success("127.0.0.1", 2116, nil, "active")
             checker:report_success("127.0.0.1", 2116, nil, "active")
             checker:report_success("127.0.0.1", 2116, nil, "active")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2116))  -- false
         }
     }
@@ -293,11 +298,12 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2118, nil, false)
+            ngx.sleep(0.002)
             checker:report_success("127.0.0.1", 2118, nil, "passive")
             checker:report_success("127.0.0.1", 2118, nil, "passive")
             checker:report_success("127.0.0.1", 2118, nil, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2118, nil))  -- false
         }
     }

--- a/t/with_resty-events/05-report_failure.t
+++ b/t/with_resty-events/05-report_failure.t
@@ -12,6 +12,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -45,8 +55,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -77,15 +85,16 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2117, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
+            ngx.sleep(0.002)
             checker:report_failure("127.0.0.1", 2117, nil, "active")
             checker:report_failure("127.0.0.1", 2113, nil, "passive")
             checker:report_failure("127.0.0.1", 2117, nil, "active")
             checker:report_failure("127.0.0.1", 2113, nil, "passive")
             checker:report_failure("127.0.0.1", 2117, nil, "active")
             checker:report_failure("127.0.0.1", 2113, nil, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2117, nil))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113, nil))  -- false
         }
@@ -121,8 +130,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -153,15 +160,16 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2117, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
+            ngx.sleep(0.002)
             checker:report_failure("127.0.0.1", 2117, nil, "active")
             checker:report_failure("127.0.0.1", 2113, nil, "passive")
             checker:report_failure("127.0.0.1", 2117, nil, "active")
             checker:report_failure("127.0.0.1", 2113, nil, "passive")
             checker:report_failure("127.0.0.1", 2117, nil, "active")
             checker:report_failure("127.0.0.1", 2113, nil, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2117, nil))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113, nil))  -- false
         }
@@ -195,8 +203,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -227,15 +233,16 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2117, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
+            ngx.sleep(0.002)
             checker:report_failure("127.0.0.1", 2117, nil, "active")
             checker:report_failure("127.0.0.1", 2113, nil, "passive")
             checker:report_failure("127.0.0.1", 2117, nil, "active")
             checker:report_failure("127.0.0.1", 2113, nil, "passive")
             checker:report_failure("127.0.0.1", 2117, nil, "active")
             checker:report_failure("127.0.0.1", 2113, nil, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2117, nil))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2113, nil))  -- true
         }

--- a/t/with_resty-events/05-report_failure.t
+++ b/t/with_resty-events/05-report_failure.t
@@ -59,7 +59,7 @@ qq{
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 type = "http",
                 checks = {
                     active = {
@@ -134,7 +134,7 @@ qq{
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 type = "tcp",
                 checks = {
                     active = {
@@ -207,7 +207,7 @@ qq{
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 type = "tcp",
                 checks = {
                     active = {

--- a/t/with_resty-events/06-report_http_status.t
+++ b/t/with_resty-events/06-report_http_status.t
@@ -12,6 +12,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -45,8 +55,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -77,15 +85,16 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
+            ngx.sleep(0.002)
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
             checker:report_http_status("127.0.0.1", 2113, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
             checker:report_http_status("127.0.0.1", 2113, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
             checker:report_http_status("127.0.0.1", 2113, nil, 500, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
@@ -122,8 +131,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -154,9 +161,9 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2119, nil, false)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, false)
+            ngx.sleep(0.002)
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
             checker:report_http_status("127.0.0.1", 2113, nil, 200, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
@@ -165,6 +172,7 @@ events_module = "resty.events",
             checker:report_http_status("127.0.0.1", 2113, nil, 200, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
             checker:report_http_status("127.0.0.1", 2113, nil, 200, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- true
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- true
         }
@@ -202,8 +210,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -234,12 +240,13 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2119, nil, false)
+            ngx.sleep(0.002)
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2119, nil))  -- false
         }
     }
@@ -267,8 +274,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -299,12 +304,13 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2119, nil, false)
+            ngx.sleep(0.002)
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
             checker:report_http_status("127.0.0.1", 2119, nil, 200, "active")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2119, nil))  -- false
         }
     }
@@ -332,8 +338,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -364,12 +368,13 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
+            ngx.sleep(0.002)
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2119))  -- true
         }
     }
@@ -397,8 +402,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -429,12 +432,13 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
+            ngx.sleep(0.002)
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "active")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2119, nil))  -- true
         }
     }
@@ -458,8 +462,6 @@ qq{
             ngx.say("OK")
         }
         log_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -479,11 +481,13 @@ events_module = "resty.events",
                 }
             })
             local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
+            ngx.sleep(0.002)
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
+            ngx.sleep(0.002)
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
         }
     }

--- a/t/with_resty-events/07-report_tcp_failure.t
+++ b/t/with_resty-events/07-report_tcp_failure.t
@@ -12,6 +12,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -45,8 +55,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -77,15 +85,16 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2120, nil, true)
             local ok, err = checker:add_target("127.0.0.1", 2113, nil, true)
+            ngx.sleep(0.002)
             checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
             checker:report_tcp_failure("127.0.0.1", 2113, nil, nil, "passive")
             checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
             checker:report_tcp_failure("127.0.0.1", 2113, nil, nil, "passive")
             checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
             checker:report_tcp_failure("127.0.0.1", 2113, nil, nil, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2120))  -- false
             ngx.say(checker:get_target_status("127.0.0.1", 2113))  -- false
         }
@@ -121,8 +130,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -153,11 +160,12 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2120, nil, true)
+            ngx.sleep(0.002)
             checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
             checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
             checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "active")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2120))  -- true
         }
     }
@@ -186,8 +194,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -218,11 +224,12 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2120, nil, true)
+            ngx.sleep(0.002)
             checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "passive")
             checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "passive")
             checker:report_tcp_failure("127.0.0.1", 2120, nil, nil, "passive")
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2120))  -- true
         }
     }

--- a/t/with_resty-events/09-active_probes.t
+++ b/t/with_resty-events/09-active_probes.t
@@ -12,6 +12,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -45,8 +55,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -102,8 +110,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -157,8 +163,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -214,8 +218,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -278,8 +280,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -323,8 +323,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -380,8 +378,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -443,8 +439,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -486,6 +480,9 @@ checking unhealthy targets: nothing to do
 qq{
     $::HttpConfig
 
+    # ignore lua tcp socket read timed out
+    lua_socket_log_errors off;
+
     server {
         listen 2114;
         location = /status {
@@ -499,8 +496,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 test = true,

--- a/t/with_resty-events/10-garbagecollect.t
+++ b/t/with_resty-events/10-garbagecollect.t
@@ -12,6 +12,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -45,14 +55,7 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            ngx.shared.my_worker_events:flush_all()
             local dump = function(...) ngx.log(ngx.DEBUG,"\027[31m\n", require("pl.pretty").write({...}),"\027[0m") end
-            local we = require "resty.events.compat"
-            assert(we.configure {
-                shm = "my_worker_events",
-                interval = 0.1,
-                debug = true,
-            })
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",

--- a/t/with_resty-events/10-garbagecollect.t
+++ b/t/with_resty-events/10-garbagecollect.t
@@ -60,7 +60,7 @@ qq{
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 type = "http",
                 checks = {
                     active = {

--- a/t/with_resty-events/11-clear.t
+++ b/t/with_resty-events/11-clear.t
@@ -12,6 +12,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -33,8 +43,6 @@ __DATA__
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local config = {
                 name = "testing",
@@ -89,8 +97,6 @@ initial target list (11 targets)
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local config = {
                 name = "testing",
@@ -143,8 +149,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local config = {
                 name = "testing",
@@ -189,8 +193,6 @@ unhealthy HTTP increment (3/3) for '(127.0.0.1:21120)'
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local config = {
                 name = "testing",
@@ -238,8 +240,6 @@ target not found
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local config = {
                 name = "testing",

--- a/t/with_resty-events/12-set_target_status.t
+++ b/t/with_resty-events/12-set_target_status.t
@@ -12,6 +12,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -36,20 +46,20 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
 events_module = "resty.events",
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
             checker:set_target_status("127.0.0.1", 2112, nil, false)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
             checker:set_target_status("127.0.0.1", 2112, nil, true)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
         }
     }
@@ -59,6 +69,8 @@ GET /t
 true
 false
 true
+
+
 === TEST 2: set_target_status() restores node after passive check disables it
 --- http_config eval
 qq{
@@ -67,8 +79,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -83,13 +93,15 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
             checker:report_http_status("127.0.0.1", 2112, nil, 500)
             checker:report_http_status("127.0.0.1", 2112, nil, 500)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
             checker:set_target_status("127.0.0.1", 2112, nil, true)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
         }
     }
@@ -99,6 +111,8 @@ GET /t
 true
 false
 true
+
+
 === TEST 3: set_target_status() resets the failure counters
 --- http_config eval
 qq{
@@ -107,8 +121,6 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
@@ -126,14 +138,16 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
             checker:report_http_status("127.0.0.1", 2112, nil, 500)
             checker:set_target_status("127.0.0.1", 2112, nil, true)
             checker:report_http_status("127.0.0.1", 2112, nil, 500)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
             checker:report_http_status("127.0.0.1", 2112, nil, 500)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
         }
     }
@@ -143,6 +157,8 @@ GET /t
 true
 true
 false
+
+
 === TEST 3: set_target_status() resets the success counters
 --- http_config eval
 qq{
@@ -151,13 +167,11 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     passive = {
                         healthy = {
@@ -170,15 +184,18 @@ events_module = "resty.events",
                     }
                 }
             })
-            ngx.sleep(0.1) -- wait for initial timers to run once
             local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.sleep(0.002)
             checker:set_target_status("127.0.0.1", 2112, nil, false)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
             checker:report_http_status("127.0.0.1", 2112, nil, 200)
             checker:set_target_status("127.0.0.1", 2112, nil, false)
             checker:report_http_status("127.0.0.1", 2112, nil, 200)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- false
             checker:report_http_status("127.0.0.1", 2112, nil, 200)
+            ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112))  -- true
         }
     }

--- a/t/with_resty-events/13-integration.t
+++ b/t/with_resty-events/13-integration.t
@@ -132,12 +132,14 @@ events_module = "resty.events",
             -- that implements the specified behavior.
             local function run_test_case(case)
                 assert(checker:set_target_status(host, port, nil, true))
+                ngx.sleep(0.002)
                 local i = 1
                 local s, f, t, o = 0, 0, 0, 0
                 local mode = true
                 for c in case:gmatch(".") do
                     if c == "S" then
                         checker:report_http_status(host, port, nil, 200, "passive")
+                        ngx.sleep(0.002)
                         s = s + 1
                         f, t, o = 0, 0, 0
                         if s == 2 then
@@ -145,6 +147,7 @@ events_module = "resty.events",
                         end
                     elseif c == "F" then
                         checker:report_http_status(host, port, nil, 500, "passive")
+                        ngx.sleep(0.002)
                         f = f + 1
                         s = 0
                         if f == 2 then
@@ -152,6 +155,7 @@ events_module = "resty.events",
                         end
                     elseif c == "T" then
                         checker:report_tcp_failure(host, port, nil, "read", "passive")
+                        ngx.sleep(0.002)
                         t = t + 1
                         s = 0
                         if t == 2 then
@@ -159,6 +163,7 @@ events_module = "resty.events",
                         end
                     elseif c == "O" then
                         checker:report_timeout(host, port, nil, "passive")
+                        ngx.sleep(0.002)
                         o = o + 1
                         s = 0
                         if o == 2 then

--- a/t/with_resty-events/16-set_all_target_statuses_for_hostname.t
+++ b/t/with_resty-events/16-set_all_target_statuses_for_hostname.t
@@ -190,7 +190,7 @@ qq{
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     passive = {
                         healthy = {
@@ -205,6 +205,7 @@ events_module = "resty.events",
             })
             checker:add_target("127.0.0.1", 2112, "rush", true)
             checker:add_target("127.0.0.2", 2112, "rush", true)
+            ngx.sleep(0.002)
             checker:set_all_target_statuses_for_hostname("rush", 2112, false)
             ngx.sleep(0.002)
             ngx.say(checker:get_target_status("127.0.0.1", 2112, "rush"))  -- false

--- a/t/with_resty-events/18-req-headers.t
+++ b/t/with_resty-events/18-req-headers.t
@@ -10,6 +10,16 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;;";
     lua_shared_dict test_shm 8m;
 
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
     server {
         server_name kong_worker_events;
         listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
@@ -41,13 +51,11 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         http_path = "/status",
@@ -92,13 +100,11 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         http_path = "/status",
@@ -142,13 +148,11 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         http_path = "/status",
@@ -193,13 +197,11 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         http_path = "/status",
@@ -244,13 +246,11 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.events.compat"
-            assert(we.configure({ unique_timeout = 5, broker_id = 0, listening = "unix:" .. ngx.config.prefix() .. "worker_events.sock" }))
             local healthcheck = require("resty.healthcheck")
             local checker = healthcheck.new({
                 name = "testing",
                 shm_name = "test_shm",
-events_module = "resty.events",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         http_path = "/status",


### PR DESCRIPTION
Add `init_worker_by_lua` and `ngx.sleep` to pass ci.

Now `10` `13` are still failed.