### PR TITLE
fix(healthchecker) port 2.x lock fixes to 1.5.x

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -42,13 +42,16 @@ local ngx_worker_id = ngx.worker.id
 local ngx_worker_pid = ngx.worker.pid
 local ssl = require("ngx.ssl")
 local resty_timer = require "resty.timer"
+local pcall = pcall
+local get_phase = ngx.get_phase
+local type = type
+local assert = assert
 
 local new_tab
 local nkeys
 local is_array
 
 do
-  local pcall = pcall
   local ok
 
   ok, new_tab = pcall(require, "table.new")
@@ -213,7 +216,118 @@ local function key_for(key_prefix, ip, port, hostname)
   return string.format("%s:%s:%s%s", key_prefix, ip, port, hostname and ":" .. hostname or "")
 end
 
+local run_locked
+do
+  local resty_lock = require "resty.lock"
 
+  local yieldable = {
+    rewrite = true,
+    access  = true,
+    content = true,
+    timer   = true,
+  }
+
+  local function run_in_timer(premature, fn, ...)
+    if premature then
+      return
+    end
+
+    return fn(...)
+  end
+
+  local function schedule(fn, ...)
+    return ngx.timer.at(0, run_in_timer, fn, ...)
+  end
+
+  -- timeout when yieldable
+  local timeout = 5
+
+  -- resty.lock consumes these options immediately, so this table can be reused
+  local opts = {
+    exptime = 10,      -- timeout after which lock is released anyway
+    timeout = timeout, -- max wait time to acquire lock
+  }
+
+  ---
+  -- Acquire a lock and run a function
+  --
+  -- The function call itself is wrapped with `pcall` to protect against
+  -- exception.
+  --
+  -- This function exhibits some special behavior when called during a
+  -- non-yieldable phase such as `init_worker` or `log`:
+  --
+  -- 1. The lock timeout is set to 0 to ensure that `resty.lock` does not
+  --    attempt to sleep/yield
+  -- 2. If acquiring the lock fails due to a timeout, `run_locked`
+  --    (this function) is re-scheduled to run in a timer. In this case,
+  --    the function returns `nil, "scheduled"`
+  --
+  -- @param self The checker object
+  -- @param key the key/identifier to acquire a lock for
+  -- @param fn The function to execute
+  -- @param ... arguments that will be passed to fn
+  -- @return The results of the function; or nil and an error message
+  -- in case it fails locking.
+  function run_locked(self, key, fn, ...)
+    -- we're extra extra extra defensive in this code path
+    local typ = type(key)
+     -- XXX is a number key ever expected?
+    assert(typ == "string" or typ == "number",
+           "unexpected lock key type: " .. typ)
+    key = tostring(key)
+
+    -- first aqcuire a lock or conditionally re-schedule ourselves in a timer
+    local lock
+    do
+      local yield = yieldable[get_phase()]
+
+      if yield then
+        opts.timeout = timeout
+      else
+        -- if yielding is not possible in the current phase, use a zero timeout
+        -- so that resty.lock will return `nil, "timeout"` immediately instead of
+        -- calling ngx.sleep()
+        opts.timeout = 0
+      end
+
+      local err
+      lock, err = resty_lock:new(self.shm_name, opts)
+      if not lock then
+        return nil, "failed creating lock for '" .. key .. "', " .. err
+      end
+
+      local elapsed
+      elapsed, err = lock:lock(key)
+
+      if not elapsed and err == "timeout" and not yield then
+        -- yielding is not possible in the current phase, so retry in a timer
+        local _, terr = schedule(run_locked, self, key, fn, ...)
+        if terr ~= nil then
+          return nil, terr
+        end
+
+        return nil, "scheduled"
+
+      elseif not elapsed then
+        return nil, "failed acquiring lock for '" .. key .. "', " .. err
+      end
+    end
+
+    local pok, perr, res = pcall(fn, ...)
+
+    local ok, err = lock:unlock()
+    if not ok then
+      self:log(ERR, "failed unlocking '", key, "', ", err)
+    end
+
+    if not pok then
+      return nil, perr
+    else
+      return perr, res
+    end
+  end
+end
 local checker = {}
 
 
@@ -280,21 +394,29 @@ local function run_fn_locked_target_list(premature, self, fn)
 end
 
 
+local function with_target_list(self, fn)
+  local targets, err = fetch_target_list(self)
+  if not targets then
+    return nil, err
+  end
+
+  -- this is only ever called in the context of `run_locked`,
+  -- so no pcall needed
+  return fn(targets)
+end
+
+
 --- Run the given function holding a lock on the target list.
 -- @param self The checker object
 -- @param fn The function to execute
 -- @return The results of the function; or nil and an error message
 -- in case it fails locking.
 local function locking_target_list(self, fn)
+  local ok, err = run_locked(self, self.TARGET_LIST_LOCK, with_target_list, self, fn)
 
-  local ok, err = run_fn_locked_target_list(false, self, fn)
-  if err == "failed to acquire lock" then
-    local _, terr = ngx.timer.at(0, run_fn_locked_target_list, self, fn)
-    if terr ~= nil then
-      return nil, terr
-    end
-
-    return true
+  if not ok and err == "scheduled" then
+    self:log(DEBUG, "target_list function re-scheduled in timer")
+    ok = true
   end
 
   return ok, err
@@ -579,14 +701,13 @@ end
 -- @return The results of the function; or true in case it fails locking and
 -- will retry asynchronously; or nil+err in case it fails to retry.
 local function locking_target(self, ip, port, hostname, fn)
-  local ok, err = run_mutexed_fn(false, self, ip, port, hostname, fn)
-  if err == "failed to acquire lock" then
-    local _, terr = ngx.timer.at(0, run_mutexed_fn, self, ip, port, hostname, fn)
-    if terr ~= nil then
-      return nil, terr
-    end
+  local key = key_for(self.TARGET_LOCK, ip, port, hostname)
 
-    return true
+  local ok, err = run_locked(self, key, fn)
+
+  if not ok and err == "scheduled" then
+    self:log(DEBUG, "target function for ", key, " was re-scheduled")
+    ok = true
   end
 
   return ok, err


### PR DESCRIPTION
Porting the changes from #112 to the 1.5.x tree.

This is still a WIP (I think I have a failing test).