### PR TITLE
chore(ci) remove old openresty versions

### DIFF
--- a/.github/workflows/build_and_test_with_resty_events.yml
+++ b/.github/workflows/build_and_test_with_resty_events.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        openresty-version: [1.15.8.3, 1.17.8.2, 1.19.9.1, 1.21.4.1]
+        openresty-version: [1.19.9.1, 1.21.4.1]
 
     steps:
       - name: Update and install OS dependencies

--- a/.github/workflows/build_and_test_with_worker_events.yml
+++ b/.github/workflows/build_and_test_with_worker_events.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        openresty-version: [1.15.8.3, 1.17.8.2, 1.19.9.1, 1.21.4.1]
+        openresty-version: [1.19.9.1, 1.21.4.1]
 
     steps:
       - name: Update and install OS dependencies


### PR DESCRIPTION
Pre-built packages for OpenResty 1.15.8.3 and 1.17.8.2 are not available anymore.