### PR TITLE
cherry-pick: use OpenResty's API for mtls (#99)

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1015,20 +1015,22 @@ function checker:run_single_check(ip, port, hostname, hostheader)
   end
 
   if self.checks.active.type == "https" then
-    local session
+    local https_sni, session, err
+    https_sni = self.checks.active.https_sni or hostheader or hostname
     if self.ssl_cert and self.ssl_key then
       session, err = sock:tlshandshake({
         verify = self.checks.active.https_verify_certificate,
         client_cert = self.ssl_cert,
-        client_priv_key = self.ssl_key
+        client_priv_key = self.ssl_key,
+        server_name = https_sni
       })
     else
-      session, err = sock:sslhandshake(nil, hostname,
+      session, err = sock:sslhandshake(nil, https_sni,
                                      self.checks.active.https_verify_certificate)
     end
     if not session then
       sock:close()
-      self:log(ERR, "failed SSL handshake with '", hostname, " (", ip, ":", port, ")': ", err)
+      self:log(ERR, "failed SSL handshake with '", hostname or "", " (", ip, ":", port, ")', using server name (sni) '", https_sni, "': ", err)
       return self:report_tcp_failure(ip, port, hostname, "connect", "active")
     end
 
@@ -1436,6 +1438,7 @@ local defaults = {
       timeout = 1,
       concurrency = 10,
       http_path = "/",
+      https_sni = NO_DEFAULT,
       https_verify_certificate = true,
       headers = {""},
       healthy = {
@@ -1502,12 +1505,13 @@ end
 --
 -- * `name`: name of the health checker
 -- * `shm_name`: the name of the `lua_shared_dict` specified in the Nginx configuration to use
--- * `checks.active.type`: "http", "https" or "tcp" (default is "http")
 -- * `ssl_cert`: certificate for mTLS connections (string or parsed object)
 -- * `ssl_key`: key for mTLS connections (string or parsed object)
+-- * `checks.active.type`: "http", "https" or "tcp" (default is "http")
 -- * `checks.active.timeout`: socket timeout for active checks (in seconds)
 -- * `checks.active.concurrency`: number of targets to check concurrently
 -- * `checks.active.http_path`: path to use in `GET` HTTP request to run on active checks
+-- * `checks.active.https_sni`: SNI server name incase of HTTPS
 -- * `checks.active.https_verify_certificate`: boolean indicating whether to verify the HTTPS certificate
 -- * `checks.active.headers`: one or more lists of values indexed by header name
 -- * `checks.active.healthy.interval`: interval between checks for healthy targets (in seconds)

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1018,16 +1018,16 @@ function checker:run_single_check(ip, port, hostname, hostheader)
     local https_sni, session, err
     https_sni = self.checks.active.https_sni or hostheader or hostname
     if self.ssl_cert and self.ssl_key then
-      session, err = sock:tlshandshake({
-        verify = self.checks.active.https_verify_certificate,
-        client_cert = self.ssl_cert,
-        client_priv_key = self.ssl_key,
-        server_name = https_sni
-      })
-    else
-      session, err = sock:sslhandshake(nil, https_sni,
-                                     self.checks.active.https_verify_certificate)
+      ok, err = sock:setclientcert(self.ssl_cert, self.ssl_key)
+
+      if not ok then
+        self:log(ERR, "failed to set client certificate: ", err)
+      end
     end
+
+    session, err = sock:sslhandshake(nil, https_sni,
+                                     self.checks.active.https_verify_certificate)
+
     if not session then
       sock:close()
       self:log(ERR, "failed SSL handshake with '", hostname or "", " (", ip, ":", port, ")', using server name (sni) '", https_sni, "': ", err)


### PR DESCRIPTION
### Summary

Cherry-picks:

- [Added support for https_sni in healthcheck.lua (](https://github.com/Kong/lua-resty-healthcheck/commit/c8c6bb67803a3f36de13b486daea94072efcdd38)https://github.com/Kong/lua-resty-healthcheck/pull/49[)](https://github.com/Kong/lua-resty-healthcheck/commit/c8c6bb67803a3f36de13b486daea94072efcdd38)
- [fix(mtls) use OpenResty's API for mtls (](https://github.com/Kong/lua-resty-healthcheck/commit/44b68d5893facde6c5232147cc1fc32f8430ec15)https://github.com/Kong/lua-resty-healthcheck/pull/99[)](https://github.com/Kong/lua-resty-healthcheck/commit/44b68d5893facde6c5232147cc1fc32f8430ec15)