### PR TITLE
fix: fix delay clean logic when multiple healthchecker was started

### DIFF
--- a/.github/workflows/build_and_test_with_resty_events.yml
+++ b/.github/workflows/build_and_test_with_resty_events.yml
@@ -147,4 +147,4 @@ jobs:
         run: |
           eval `luarocks path`
           eval $(perl -I $HOME/perl5/lib/perl5/ -Mlocal::lib)
-          TEST_NGINX_RANDOMIZE=1 prove -I. -r t/with_resty-events
+          TEST_NGINX_TIMEOUT=4 TEST_NGINX_RANDOMIZE=1 prove -I. -r t/with_resty-events

--- a/.github/workflows/build_and_test_with_worker_events.yml
+++ b/.github/workflows/build_and_test_with_worker_events.yml
@@ -72,4 +72,4 @@ jobs:
         run: |
           eval `luarocks path`
           eval $(perl -I $HOME/perl5/lib/perl5/ -Mlocal::lib)
-          TEST_NGINX_RANDOMIZE=1 prove -I. -r t/with_worker-events
+          TEST_NGINX_TIMEOUT=4 TEST_NGINX_RANDOMIZE=1 prove -I. -r t/with_worker-events

--- a/.github/workflows/build_and_test_with_worker_events.yml
+++ b/.github/workflows/build_and_test_with_worker_events.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        openresty-version: [1.19.9.1, 1.21.4.1]
+        openresty-version: [1.21.4.1]
 
     steps:
       - name: Update and install OS dependencies

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1690,9 +1690,11 @@ function _M.new(opts)
         end
 
         local cur_time = ngx_now()
+        local is_checked = false
         for _, checker_obj in pairs(hcs) do
 
           if (last_cleanup_check + CLEANUP_INTERVAL) < cur_time then
+            is_checked = true
             -- clear targets marked for delayed removal
             locking_target_list(checker_obj, function(target_list)
               local removed_targets = {}
@@ -1721,8 +1723,6 @@ function _M.new(opts)
                 end
               end
             end)
-
-            last_cleanup_check = cur_time
           end
 
           if checker_obj.checks.active.healthy.active and
@@ -1740,6 +1740,10 @@ function _M.new(opts)
             checker_obj.checks.active.unhealthy.last_run = cur_time
             checker_callback(checker_obj, "unhealthy")
           end
+        end
+
+        if is_checked then
+          last_cleanup_check = cur_time
         end
       end,
     })

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1694,9 +1694,9 @@ function _M.new(opts)
         for _, checker_obj in pairs(hcs) do
 
           if (last_cleanup_check + CLEANUP_INTERVAL) < cur_time then
-            is_checked = true
             -- clear targets marked for delayed removal
             locking_target_list(checker_obj, function(target_list)
+              is_checked = true
               local removed_targets = {}
               local index = 1
               while index <= #target_list do

--- a/t/with_resty-events/11-clear.t
+++ b/t/with_resty-events/11-clear.t
@@ -302,8 +302,6 @@ target not found
 --- config
     location = /t {
         content_by_lua_block {
-            local we = require "resty.worker.events"
-            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
             local healthcheck = require("resty.healthcheck")
             local config1 = {
                 name = "testing",

--- a/t/with_resty-events/11-clear.t
+++ b/t/with_resty-events/11-clear.t
@@ -339,12 +339,14 @@ target not found
             checker1:add_target("127.0.0.1", 10001, nil, true)
             checker1:add_target("127.0.0.1", 10002, nil, true)
             checker1:add_target("127.0.0.1", 10003, nil, true)
+            ngx.sleep(0.2)
             ngx.say(checker1:get_target_status("127.0.0.1", 10002))
             checker1:delayed_clear(0.2)
 
             local checker2 = healthcheck.new(config2)
             checker2:add_target("127.0.0.1", 10001, nil, true)
             checker2:add_target("127.0.0.1", 10002, nil, true)
+            ngx.sleep(0.2)
             ngx.say(checker2:get_target_status("127.0.0.1", 10002))
             checker2:delayed_clear(0.2)
 

--- a/t/with_resty-events/11-clear.t
+++ b/t/with_resty-events/11-clear.t
@@ -308,6 +308,7 @@ target not found
             local config1 = {
                 name = "testing",
                 shm_name = "test_shm",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         healthy  = {
@@ -323,6 +324,7 @@ target not found
             local config2 = {
                 name = "testing2",
                 shm_name = "test_shm",
+                events_module = "resty.events",
                 checks = {
                     active = {
                         healthy  = {

--- a/t/with_worker-events/11-clear.t
+++ b/t/with_worker-events/11-clear.t
@@ -3,7 +3,7 @@ use Cwd qw(cwd);
 
 workers(1);
 
-plan tests => repeat_each() * 27;
+plan tests => repeat_each() * 27 + 2;
 
 my $pwd = cwd();
 
@@ -279,4 +279,87 @@ false
 false
 target not found
 false
+target not found
+
+
+=== TEST 6: delayed_clear() would clear tgt list when we add two checkers
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+            local config1 = {
+                name = "testing",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy  = {
+                            interval = 0.1
+                        },
+                        unhealthy  = {
+                            interval = 0.1
+                        }
+                    }
+                }
+            }
+
+            local config2 = {
+                name = "testing2",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy  = {
+                            interval = 0.1
+                        },
+                        unhealthy  = {
+                            interval = 0.1
+                        }
+                    }
+                }
+            }
+
+            local checker1 = healthcheck.new(config1)
+            checker1:add_target("127.0.0.1", 10001, nil, true)
+            checker1:add_target("127.0.0.1", 10002, nil, true)
+            checker1:add_target("127.0.0.1", 10003, nil, true)
+            ngx.say(checker1:get_target_status("127.0.0.1", 10002))
+            checker1:delayed_clear(0.2)
+
+            local checker2 = healthcheck.new(config2)
+            checker2:add_target("127.0.0.1", 10001, nil, true)
+            checker2:add_target("127.0.0.1", 10002, nil, true)
+            ngx.say(checker2:get_target_status("127.0.0.1", 10002))
+            checker2:delayed_clear(0.2)
+
+            ngx.sleep(3) -- wait twice the interval
+
+            local status, err = checker1:get_target_status("127.0.0.1", 10001)
+            if status ~= nil then
+                ngx.say(status)
+            else
+                ngx.say(err)
+            end
+            status, err = checker2:get_target_status("127.0.0.1", 10002)
+            if status ~= nil then
+                ngx.say(status)
+            else
+                ngx.say(err)
+            end
+            status, err = checker2:get_target_status("127.0.0.1", 10003)
+            if status ~= nil then
+                ngx.say(status)
+            else
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+true
+target not found
+target not found
 target not found


### PR DESCRIPTION
When we have many healthchecker instance, if we need to delay clear anyone, it will add all `delay_purge` number to these target table, And then wait active healthcheck timer to check these number flag to execute real clear logic. Ideally, it's  work expected, but we have one for loop bug in clear logic. which will case delay clear logic just execute once for first healthchecker instance. So this will cause delay clear can not remove some target expectedly.

https://github.com/Kong/lua-resty-healthcheck/blob/master/lib/resty/healthcheck.lua#L1725

<img width="1043" alt="image" src="https://github.com/Kong/lua-resty-healthcheck/assets/39181969/f1ff4165-91fb-48a5-a485-fd3e927488a9">


FTI-5478