### PR TITLE
fix(healthcheck): replace checker callback timer with ngx.thread to lower timer usage

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1245,7 +1245,11 @@ local function checker_callback(self, health_mode)
       self:log(ERR, "failed to create thread to check ", health_mode)
       return
     end
-    ngx.thread.wait(thread)
+
+    local ok, err = ngx.thread.wait(thread)
+    if not ok then
+      self:log(ERR, "failed to wait for thread to check ", health_mode, ": ", err)
+    end
   end
 end
 

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1241,11 +1241,6 @@ local function checker_callback(self, health_mode)
       self:active_check_targets(list)
     end, health_mode, list_to_check)
 
-    if thread == nil then
-      self:log(ERR, "failed to create thread to check ", health_mode)
-      return
-    end
-
     local ok, err = ngx.thread.wait(thread)
     if not ok then
       self:log(ERR, "failed to wait for thread to check ", health_mode, ": ", err)


### PR DESCRIPTION
This PR modifies the way that `checker_callback` spawns the background checker for targets.

Previously the checker spawns timers with 0 delay. When the user has defined a huge amount of upstream targets with small check intervals, this may result in running timers hitting the limit in OpenResty. FTI-5847 provides a similar case that due to the nature of timer-ng, this results in a memory "leaking" due to an unlimited number of timers being spawned every interval and the timer job consuming speed cannot catch up with timer creating speed.

The PR tries to modify the checker to spawn light thread directly by using `ngx.thread.spawn` since there is no need for spawning timers(which are also light threads by nature), so that we can keep behaviour the same as before as much as possible.

Alleviates FTI-5847