### PR TITLE
feat(lib): support lua-resty-events 0.1.x and 0.2.x

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -48,7 +48,7 @@ local type = type
 local assert = assert
 
 
-local RESTY_EVENTS_VER = [[^0\.1\.\d+$]]
+local RESTY_EVENTS_VER = [[^0\.[12]\.\d+$]]
 local RESTY_WORKER_EVENTS_VER = "0.3.3"
 
 


### PR DESCRIPTION
 lua-resty-events is still in active development, we should support more possible versions.

KAG-4605