### PR TITLE
fix(healthcheck): avoid self.targets is nil

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1760,7 +1760,7 @@ function _M.new(opts)
   end
 
   -- other properties
-  self.targets = nil     -- list of targets, initially loaded, maintained by events
+  self.targets = {}     -- list of targets, initially loaded, maintained by events
   self.events = nil      -- hash table with supported events (prevent magic strings)
   self.ev_callback = nil -- callback closure per checker instance
 


### PR DESCRIPTION
### Summary

The fix added in #44 was not included in lua-resty-healthcheck 3 series when 2.0.0 was discarded.

This is the original PR description:
> when two worker create checker, worker-0 first created and add target success, then worker-1 creating, when worker-1 call worker_events:poll() in line 1408, raise crash.
self.targets init with empty table avoid this.

### Issue reference

Fixes #43
Fixes #167

KAG-6920
