### PR TITLE
chore(ci): removed duplicated concurrency entry

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,6 @@ on:
       - main
       - master
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   lua-check:
     name: Lua Check


### PR DESCRIPTION
### Summary

It seems at some point we mixed up confs on merging yaml files from 1.x and 2.x series workflows. This change will bring the `lint` workflow back.