### PR TITLE
fix(targetlist): warn when no target matches in set_all_target_statuses_for_hostname

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -907,14 +907,23 @@ function checker:set_all_target_statuses_for_hostname(hostname, port, is_healthy
 
   local all_ok = true
   local errs = {}
+  local matched = 0
+
   for _, target in ipairs(self.targets) do
     if target.port == port and target.hostname == hostname then
+      matched = matched + 1
+
       local ok, err = self:set_target_status(target.ip, port, hostname, is_healthy)
       if not ok then
         all_ok = nil
         table.insert(errs, err)
       end
     end
+  end
+
+  if matched == 0 then
+    -- sync issue: warn, but return success (mirrors set_target_status)
+    self:log(WARN, "trying to set status for targets that are not in the list: ", hostname, ":", port)
   end
 
   return all_ok, #errs > 0 and table_concat(errs, "; ") or nil

--- a/t/with_resty-events/16-set_all_target_statuses_for_hostname.t
+++ b/t/with_resty-events/16-set_all_target_statuses_for_hostname.t
@@ -3,7 +3,7 @@ use Cwd qw(cwd);
 
 workers(1);
 
-plan tests => repeat_each() * blocks() * 2;
+plan tests => repeat_each() * (blocks() * 2 + 1);
 
 my $pwd = cwd();
 $ENV{TEST_NGINX_SERVROOT} = server_root();
@@ -231,3 +231,33 @@ false
 false
 true
 false
+
+
+
+=== TEST 5: set_all_target_statuses_for_hostname() warns when nothing matches
+--- http_config eval
+qq{
+    $::HttpConfig
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+events_module = "resty.events",
+            })
+            local ok, err = checker:set_all_target_statuses_for_hostname("rush", 2112, false)
+            ngx.say(ok)   -- true
+            ngx.say(err)  -- nil
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+nil
+--- error_log
+trying to set status for targets that are not in the list: rush:2112
+

--- a/t/with_worker-events/16-set_all_target_statuses_for_hostname.t
+++ b/t/with_worker-events/16-set_all_target_statuses_for_hostname.t
@@ -3,7 +3,7 @@ use Cwd qw(cwd);
 
 workers(1);
 
-plan tests => repeat_each() * blocks() * 2;
+plan tests => repeat_each() * blocks() * 2 + 1;
 
 my $pwd = cwd();
 
@@ -199,3 +199,35 @@ false
 false
 true
 false
+
+
+
+=== TEST 5: set_all_target_statuses_for_hostname() warns when nothing matches
+--- http_config eval
+qq{
+    $::HttpConfig
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm"
+            })
+            ngx.sleep(0.1) -- wait for initial timers to run once
+            local ok, err = checker:set_all_target_statuses_for_hostname("rush", 2112, false)
+            ngx.say(ok)   -- true
+            ngx.say(err)  -- nil
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+nil
+--- error_log
+trying to set status for targets that are not in the list: rush:2112
+


### PR DESCRIPTION
`set_all_target_statuses_for_hostname()` iterates `self.targets` and returns `true` when no entry matches the given hostname and port, which is indistinguishable from having successfully updated N targets.

`self.targets` is only populated by the "target added" worker event, while `add_target()` writes to the shm synchronously. In the window between the two, a caller posting health for a freshly added target matches nothing, the update is silently dropped, and nothing replays it later — the event that eventually arrives carries the initial status from `add_target()`.

Kong surfaces this as `PUT /upstreams/:id/targets/:target/unhealthy` returning 204 while the target stays healthy, leaving no trace in the logs.

Log a warning on zero matches, mirroring `set_target_status()`, which already warns when the target is not in the list. The return value is unchanged so existing callers keep their behaviour.

Note that targets with weight 0 are never added to the healthchecker, so posting health for them legitimately matches nothing and will now emit this warning.

Fix: [FTI-7826](https://konghq.atlassian.net/browse/FTI-7826)

[FTI-7826]: https://konghq.atlassian.net/browse/FTI-7826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ